### PR TITLE
feat: Implement Terraform workspaces for multi-environment management

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -42,15 +42,15 @@ Once these steps are complete, you can proceed to create the GCS bucket.
 **Example `gcloud` command to create such a bucket:**
 
 ```sh
-gcloud storage buckets create gs://your-unique-project-name-tfstate \
+gcloud storage buckets create gs://the-academy-sync-claude-tfstate \
     --project=your-gcp-project-id \
     --location=europe-central2 \
     --uniform-bucket-level-access \
     --public-access-prevention
-gcloud storage buckets update gs://your-unique-project-name-tfstate --versioning
+gcloud storage buckets update gs://the-academy-sync-claude-tfstate --versioning
 ```
 
-Replace `your-unique-project-name-tfstate` and `your-gcp-project-id` with your actual values.
+Replace `your-gcp-project-id` with your actual project ID. The bucket name `the-academy-sync-claude-tfstate` is used as an example.
 
 ### Updating `backend.tf`
 
@@ -59,13 +59,13 @@ Once the bucket is created, you need to update the `terraform/backend.tf` file:
 ```terraform
 terraform {
   backend "gcs" {
-    bucket  = "your-gcs-bucket-name-here"  // TODO: Replace with your actual GCS bucket name
-    prefix  = "the-academy-sync/state"
+    bucket  = "the-academy-sync-claude-tfstate"
+    prefix  = "tf-state/${terraform.workspace}" // Example, assuming workspace usage is now standard
   }
 }
 ```
 
-Replace `"your-gcs-bucket-name-here"` with the actual name of the GCS bucket you created.
+The `bucket` attribute should be set to the name of the GCS bucket you created (e.g., `the-academy-sync-claude-tfstate`). The `prefix` is configured to support Terraform workspaces.
 
 ### Initializing Terraform
 
@@ -135,4 +135,4 @@ To deploy or make changes to an environment, first select the appropriate worksp
    terraform apply -var-file="prod.tfvars"
    ```
 
-Remember to replace `"your-gcs-bucket-name-here"` in the `backend.tf` file and the project IDs in `staging.tfvars` and `prod.tfvars` with your actual values.
+Remember to ensure the `bucket` in `backend.tf` is set to your GCS bucket name (e.g., `the-academy-sync-claude-tfstate`) and update the project IDs in `staging.tfvars` and `prod.tfvars` with your actual values.

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -59,8 +59,8 @@ Once the bucket is created, you need to update the `terraform/backend.tf` file:
 ```terraform
 terraform {
   backend "gcs" {
-    bucket  = "the-academy-sync-claude-tfstate"
-    prefix  = "tf-state/${terraform.workspace}" // Example, assuming workspace usage is now standard
+    bucket = "the-academy-sync-claude-tfstate"
+    prefix = "tf-state"
   }
 }
 ```
@@ -83,7 +83,7 @@ After successful initialization, any `terraform apply` commands will store the s
 
 This project uses Terraform Workspaces to manage multiple deployment environments (e.g., staging, production) from a single codebase. Each workspace maintains its own state file, allowing for independent and safe infrastructure management.
 
-The backend is configured to store state files in GCS under a path specific to each workspace (e.g., `gs://<your-bucket-name>/tf-state/staging`, `gs://<your-bucket-name>/tf-state/prod`).
+The backend is configured to store state files in GCS. Terraform automatically creates workspace-specific paths within the bucket (e.g., `gs://the-academy-sync-claude-tfstate/tf-state/env:/staging/`, `gs://the-academy-sync-claude-tfstate/tf-state/env:/prod/`).
 
 ### Creating Workspaces
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -78,3 +78,61 @@ terraform init
 This command will download the necessary provider plugins and configure the backend to use your GCS bucket. You should see a message like "Successfully configured the backend 'gcs'".
 
 After successful initialization, any `terraform apply` commands will store the state in the configured GCS bucket.
+
+## Managing Environments with Workspaces
+
+This project uses Terraform Workspaces to manage multiple deployment environments (e.g., staging, production) from a single codebase. Each workspace maintains its own state file, allowing for independent and safe infrastructure management.
+
+The backend is configured to store state files in GCS under a path specific to each workspace (e.g., `gs://<your-bucket-name>/tf-state/staging`, `gs://<your-bucket-name>/tf-state/prod`).
+
+### Creating Workspaces
+
+If they don't already exist, you can create workspaces for different environments. For example, to create `staging` and `prod` workspaces:
+
+```sh
+terraform workspace new staging
+terraform workspace new prod
+```
+
+The `default` workspace is present initially. It's recommended to create specific workspaces for your environments rather than using `default` for any particular environment.
+
+### Selecting a Workspace
+
+Before running any Terraform commands for a specific environment, you need to select its workspace:
+
+```sh
+terraform workspace select staging
+```
+Or for production:
+```sh
+terraform workspace select prod
+```
+You can list available workspaces with `terraform workspace list`.
+
+### Applying Environment-Specific Configurations
+
+To deploy or make changes to an environment, first select the appropriate workspace. Then, use the `-var-file` flag with `terraform apply` (or `plan`) to specify the environment's configuration file:
+
+**For Staging:**
+1. Select the staging workspace:
+   ```sh
+   terraform workspace select staging
+   ```
+2. Apply the configuration using `staging.tfvars`:
+   ```sh
+   terraform plan -var-file="staging.tfvars"
+   terraform apply -var-file="staging.tfvars"
+   ```
+
+**For Production:**
+1. Select the production workspace:
+   ```sh
+   terraform workspace select prod
+   ```
+2. Apply the configuration using `prod.tfvars`:
+   ```sh
+   terraform plan -var-file="prod.tfvars"
+   terraform apply -var-file="prod.tfvars"
+   ```
+
+Remember to replace `"your-gcs-bucket-name-here"` in the `backend.tf` file and the project IDs in `staging.tfvars` and `prod.tfvars` with your actual values.

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,6 +1,6 @@
 terraform {
   backend "gcs" {
-    bucket  = "the-academy-sync-claude-tfstate"
-    prefix  = "tf-state/${terraform.workspace}"
+    bucket = "the-academy-sync-claude-tfstate"
+    prefix = "tf-state"
   }
 }

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,6 +1,6 @@
 terraform {
   backend "gcs" {
     bucket  = "your-gcs-bucket-name-here"  // TODO: Replace with your actual GCS bucket name
-    prefix  = "the-academy-sync/state"     // This will store the state under gs://your-gcs-bucket-name-here/the-academy-sync/state
+    prefix  = "tf-state/${terraform.workspace}"     // This will store the state under gs://<bucket_name>/tf-state/<workspace_name>
   }
 }

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,6 +1,6 @@
 terraform {
   backend "gcs" {
-    bucket  = "your-gcs-bucket-name-here"  // TODO: Replace with your actual GCS bucket name
-    prefix  = "tf-state/${terraform.workspace}"     // This will store the state under gs://<bucket_name>/tf-state/<workspace_name>
+    bucket  = "the-academy-sync-claude-tfstate"
+    prefix  = "tf-state/${terraform.workspace}"
   }
 }

--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -1,0 +1,6 @@
+# Production Environment Configuration
+
+project_id     = "your-production-project-id" // TODO: Replace with actual production project ID
+region         = "us-central1"
+machine_type   = "e2-standard-2" // Example: larger machine type for production
+instance_count = 3               // Example: more instances for production

--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -1,6 +1,4 @@
 # Production Environment Configuration
 
-project_id     = "your-production-project-id" // TODO: Replace with actual production project ID
-region         = "us-central1"
-machine_type   = "e2-standard-2" // Example: larger machine type for production
-instance_count = 3               // Example: more instances for production
+project_id = "the-academy-sync-sdlc-test"
+region     = "europe-central2"

--- a/terraform/staging.tfvars
+++ b/terraform/staging.tfvars
@@ -1,6 +1,4 @@
 # Staging Environment Configuration
 
-project_id     = "your-staging-project-id" // TODO: Replace with actual staging project ID
-region         = "us-west1"
-machine_type   = "e2-small"
-instance_count = 1
+project_id = "the-academy-sync-sdlc-test"
+region     = "europe-central2"

--- a/terraform/staging.tfvars
+++ b/terraform/staging.tfvars
@@ -1,0 +1,6 @@
+# Staging Environment Configuration
+
+project_id     = "your-staging-project-id" // TODO: Replace with actual staging project ID
+region         = "us-west1"
+machine_type   = "e2-small"
+instance_count = 1

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -6,17 +6,5 @@ variable "project_id" {
 variable "region" {
   description = "The GCP region where resources will be deployed."
   type        = string
-  default     = "us-central1" // Example default, can be overridden
-}
-
-variable "machine_type" {
-  description = "The machine type for compute instances."
-  type        = string
-  default     = "e2-medium" // Example default, can be overridden
-}
-
-variable "instance_count" {
-  description = "The number of instances to create."
-  type        = number
-  default     = 1 // Example default, can be overridden
+  default     = "europe-central2"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,22 @@
+variable "project_id" {
+  description = "The GCP project ID to deploy resources into."
+  type        = string
+}
+
+variable "region" {
+  description = "The GCP region where resources will be deployed."
+  type        = string
+  default     = "us-central1" // Example default, can be overridden
+}
+
+variable "machine_type" {
+  description = "The machine type for compute instances."
+  type        = string
+  default     = "e2-medium" // Example default, can be overridden
+}
+
+variable "instance_count" {
+  description = "The number of instances to create."
+  type        = number
+  default     = 1 // Example default, can be overridden
+}


### PR DESCRIPTION
This commit introduces Terraform workspaces to manage multiple deployment environments (e.g., staging, production) from a single codebase.

Key changes:

- Modified `terraform/backend.tf` to use workspace-specific paths for storing state files in GCS (e.g., `gs://<bucket>/tf-state/${terraform.workspace}`).
- Created `terraform/variables.tf` to declare common variables with sensible defaults.
- Added `terraform/staging.tfvars` and `terraform/prod.tfvars` to define environment-specific configurations.
- Updated `terraform/README.md` with comprehensive instructions on how to:
    - Create new workspaces (`terraform workspace new <name>`)
    - Select workspaces (`terraform workspace select <name>`)
    - Apply configurations using environment-specific var-files (`terraform apply -var-file="<env>.tfvars"`)

This setup allows for independent and safer management of each environment's infrastructure, addressing issue TECH-005. Closes #32 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added environment-specific configuration files for production and staging deployments.
  - Introduced input variables for project ID and region selection.

- **Documentation**
  - Updated Terraform README with detailed instructions for managing multiple environments using workspaces.
  - Provided clearer guidance on backend configuration and workspace-specific state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->