### PR TITLE
Add row count validation to database update methods

### DIFF
--- a/internal/pkg/database/user_repository.go
+++ b/internal/pkg/database/user_repository.go
@@ -204,15 +204,43 @@ func (r *UserRepository) UpdateUserTokens(ctx context.Context, req *UpdateUserTo
 		}
 	}
 
-	_, err = r.db.ExecContext(ctx, query, args...)
-	return err
+	result, err := r.db.ExecContext(ctx, query, args...)
+	if err != nil {
+		return err
+	}
+	
+	// Check that exactly one row was affected
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	
+	if rowsAffected == 0 {
+		return sql.ErrNoRows // No user found with the given ID
+	}
+	
+	return nil
 }
 
 // UpdateLastLoginAt updates the user's last login timestamp
 func (r *UserRepository) UpdateLastLoginAt(ctx context.Context, userID int) error {
 	query := `UPDATE users SET last_login_at = $1, updated_at = $2 WHERE id = $3`
-	_, err := r.db.ExecContext(ctx, query, time.Now(), time.Now(), userID)
-	return err
+	result, err := r.db.ExecContext(ctx, query, time.Now(), time.Now(), userID)
+	if err != nil {
+		return err
+	}
+	
+	// Check that exactly one row was affected
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	
+	if rowsAffected == 0 {
+		return sql.ErrNoRows // No user found with the given ID
+	}
+	
+	return nil
 }
 
 // GetDecryptedGoogleTokens retrieves and decrypts a user's Google OAuth tokens


### PR DESCRIPTION
## Summary
- Add row count validation to UserRepository update methods to prevent silent failures
- Check rows affected in UpdateUserTokens and UpdateLastLoginAt methods
- Return sql.ErrNoRows when no rows are updated for consistency with other database operations

## Changes
- Enhanced `UpdateUserTokens` method with row count validation
- Enhanced `UpdateLastLoginAt` method with row count validation  
- Both methods now detect invalid user IDs and concurrent deletions
- Prevents silent no-ops that could mask application bugs

## Test Plan
- [x] All existing database tests pass
- [x] Code compiles without errors
- [x] Methods now properly fail when user ID doesn't exist

🤖 Generated with [Claude Code](https://claude.ai/code)