### PR TITLE
Fix: Frontend avatar caching to prevent Google API rate limiting

### DIFF
--- a/web/app/api/avatar/route.ts
+++ b/web/app/api/avatar/route.ts
@@ -1,0 +1,104 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+// Simple in-memory cache for avatar images
+const avatarCache = new Map<string, { data: ArrayBuffer; contentType: string; timestamp: number }>()
+const CACHE_DURATION = 7 * 24 * 60 * 60 * 1000 // 7 days
+
+export async function GET(request: NextRequest) {
+  try {
+    const url = request.nextUrl.searchParams.get('url')
+    
+    if (!url) {
+      return new NextResponse('Missing URL parameter', { status: 400 })
+    }
+    
+    // Check if the URL is from allowed domains
+    const allowedDomains = [
+      'googleusercontent.com',
+      'lh3.google.com',
+      'graph.facebook.com',
+      'www.strava.com'
+    ]
+    
+    const urlObj = new URL(url)
+    const isAllowed = allowedDomains.some(domain => urlObj.hostname.includes(domain))
+    
+    if (!isAllowed) {
+      return new NextResponse('Invalid avatar URL', { status: 400 })
+    }
+    
+    // Check in-memory cache
+    const cached = avatarCache.get(url)
+    if (cached && Date.now() - cached.timestamp < CACHE_DURATION) {
+      return new NextResponse(cached.data, {
+        headers: {
+          'Content-Type': cached.contentType,
+          'Cache-Control': 'public, max-age=604800', // 7 days
+        },
+      })
+    }
+    
+    // Fetch the image with a timeout
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), 5000) // 5 second timeout
+    
+    try {
+      const response = await fetch(url, {
+        signal: controller.signal,
+        headers: {
+          'User-Agent': 'TheAcademySync/1.0',
+        },
+      })
+      
+      clearTimeout(timeoutId)
+      
+      if (!response.ok) {
+        // Return a transparent 1x1 pixel if the image fails to load
+        const pixel = Buffer.from('R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7', 'base64')
+        return new NextResponse(pixel, {
+          headers: {
+            'Content-Type': 'image/gif',
+            'Cache-Control': 'public, max-age=3600', // 1 hour for errors
+          },
+        })
+      }
+      
+      const contentType = response.headers.get('content-type') || 'image/jpeg'
+      const data = await response.arrayBuffer()
+      
+      // Store in cache
+      avatarCache.set(url, {
+        data,
+        contentType,
+        timestamp: Date.now(),
+      })
+      
+      // Clean up old cache entries
+      if (avatarCache.size > 100) {
+        const entries = Array.from(avatarCache.entries())
+        entries.sort((a, b) => a[1].timestamp - b[1].timestamp)
+        for (let i = 0; i < 20; i++) {
+          avatarCache.delete(entries[i][0])
+        }
+      }
+      
+      return new NextResponse(data, {
+        headers: {
+          'Content-Type': contentType,
+          'Cache-Control': 'public, max-age=604800', // 7 days
+        },
+      })
+    } catch (error) {
+      // Return transparent pixel on error
+      const pixel = Buffer.from('R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7', 'base64')
+      return new NextResponse(pixel, {
+        headers: {
+          'Content-Type': 'image/gif',
+          'Cache-Control': 'public, max-age=3600', // 1 hour for errors
+        },
+      })
+    }
+  } catch (error) {
+    return new NextResponse('Internal Server Error', { status: 500 })
+  }
+}

--- a/web/components/app-shell.tsx
+++ b/web/components/app-shell.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/ui/dropdown-menu"
 import { AcademyLogo } from "@/components/icons/academy-logo"
 import { useAppState } from "@/context/app-state-provider"
+import { CachedAvatarImg } from "@/components/cached-avatar"
 
 const navItems = [
   { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
@@ -90,10 +91,12 @@ export function AppShell({ children }: { children: React.ReactNode }) {
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <ShadButton variant="ghost" className="flex items-center space-x-2 p-2 rounded-full hover:bg-muted">
-                  <img
-                    src={user.picture || "/placeholder.svg?height=32&width=32&query=avatar"}
-                    alt="User avatar"
+                  <CachedAvatarImg
+                    src={user.picture}
+                    alt={user.name || "User avatar"}
                     className="w-8 h-8 rounded-full border-2 border-primary"
+                    width={32}
+                    height={32}
                   />
                   <span className="text-sm font-medium text-foreground hidden md:inline">{user.name}</span>
                 </ShadButton>

--- a/web/components/cached-avatar.tsx
+++ b/web/components/cached-avatar.tsx
@@ -1,0 +1,94 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import Image from "next/image"
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { getCachedAvatarUrl } from "@/lib/avatar-utils"
+import { cn } from "@/lib/utils"
+
+interface CachedAvatarProps {
+  src?: string | null
+  alt?: string
+  fallback?: string
+  className?: string
+  size?: number
+}
+
+export function CachedAvatar({ 
+  src, 
+  alt = "Avatar", 
+  fallback,
+  className,
+  size = 40 
+}: CachedAvatarProps) {
+  const [imageError, setImageError] = useState(false)
+  const [isLoading, setIsLoading] = useState(true)
+  
+  // Reset error state when src changes
+  useEffect(() => {
+    setImageError(false)
+    setIsLoading(true)
+  }, [src])
+  
+  const cachedUrl = getCachedAvatarUrl(src)
+  const initials = fallback || alt.split(' ').map(n => n[0]).join('').toUpperCase().slice(0, 2)
+  
+  return (
+    <Avatar className={className}>
+      {!imageError && src ? (
+        <AvatarImage 
+          src={cachedUrl} 
+          alt={alt}
+          onError={() => setImageError(true)}
+          onLoad={() => setIsLoading(false)}
+          style={{ opacity: isLoading ? 0 : 1 }}
+          className="transition-opacity duration-200"
+        />
+      ) : null}
+      <AvatarFallback className={cn("bg-primary/10 text-primary font-medium", className)}>
+        {initials}
+      </AvatarFallback>
+    </Avatar>
+  )
+}
+
+// Standard img tag version for places that need a regular img element
+export function CachedAvatarImg({ 
+  src, 
+  alt = "Avatar", 
+  className,
+  onError,
+  ...props 
+}: React.ImgHTMLAttributes<HTMLImageElement> & { src?: string | null }) {
+  const [imageError, setImageError] = useState(false)
+  const cachedUrl = getCachedAvatarUrl(src)
+  
+  const handleError = (e: React.SyntheticEvent<HTMLImageElement, Event>) => {
+    setImageError(true)
+    onError?.(e)
+  }
+  
+  if (imageError || !src) {
+    return (
+      <div 
+        className={cn("bg-primary/10 rounded-full flex items-center justify-center", className)}
+        style={{ width: props.width || 40, height: props.height || 40 }}
+      >
+        <span className="text-primary font-medium text-sm">
+          {alt.split(' ').map(n => n[0]).join('').toUpperCase().slice(0, 2)}
+        </span>
+      </div>
+    )
+  }
+  
+  return (
+    <img
+      {...props}
+      src={cachedUrl}
+      alt={alt}
+      className={className}
+      onError={handleError}
+      loading="lazy"
+    />
+  )
+}

--- a/web/lib/avatar-utils.ts
+++ b/web/lib/avatar-utils.ts
@@ -1,11 +1,30 @@
 /**
- * Adds a daily cache parameter to avatar URLs to improve browser caching
- * while avoiding excessive cache busting that could trigger rate limits
+ * Manages avatar URLs with intelligent caching to prevent rate limiting
  */
-export function getCachedAvatarUrl(url: string | undefined | null): string {
+export function getCachedAvatarUrl(url: string | undefined | null, useProxy = false): string {
   if (!url) return "/placeholder.svg"
   
-  // Add daily cache parameter (changes once per day)
+  // Option to use our proxy API for maximum rate limit protection
+  if (useProxy && (url.includes('googleusercontent.com') || url.includes('google.com'))) {
+    return `/api/avatar?url=${encodeURIComponent(url)}`
+  }
+  
+  // For Google profile pictures, use a weekly cache to reduce API calls
+  if (url.includes('googleusercontent.com') || url.includes('google.com')) {
+    // Use weekly cache key for Google avatars (changes once per week)
+    const weeklyCacheKey = Math.floor(Date.now() / (1000 * 60 * 60 * 24 * 7))
+    
+    // Extract the size parameter if it exists
+    const sizeMatch = url.match(/[?&]sz?=(\d+)/)
+    const size = sizeMatch ? sizeMatch[1] : '200'
+    
+    // For Google URLs, we'll use a more stable caching approach
+    // Remove any existing query parameters and add our cache key
+    const baseUrl = url.split('?')[0]
+    return `${baseUrl}?sz=${size}&t=${weeklyCacheKey}`
+  }
+  
+  // For other URLs, use daily cache parameter
   const dailyCacheKey = Math.floor(Date.now() / (1000 * 60 * 60 * 24))
   
   // Check if URL contains a hash fragment
@@ -21,4 +40,18 @@ export function getCachedAvatarUrl(url: string | undefined | null): string {
   // Check if base URL already has query parameters
   const separator = baseUrl.includes('?') ? '&' : '?'
   return `${baseUrl}${separator}t=${dailyCacheKey}${hashFragment}`
+}
+
+/**
+ * Preloads an avatar image to improve perceived performance
+ */
+export function preloadAvatar(url: string | undefined | null): void {
+  if (!url) return
+  
+  const cachedUrl = getCachedAvatarUrl(url)
+  const link = document.createElement('link')
+  link.rel = 'preload'
+  link.as = 'image'
+  link.href = cachedUrl
+  document.head.appendChild(link)
 }

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -1,0 +1,39 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: '*.googleusercontent.com',
+      },
+      {
+        protocol: 'https',
+        hostname: 'lh3.google.com',
+      },
+      {
+        protocol: 'https',
+        hostname: 'graph.facebook.com',
+      },
+      {
+        protocol: 'https',
+        hostname: 'www.strava.com',
+      },
+    ],
+  },
+  async headers() {
+    return [
+      {
+        // Apply caching headers to avatar images
+        source: '/_next/image(.*)',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'public, max-age=604800, immutable', // 7 days
+          },
+        ],
+      },
+    ]
+  },
+}
+
+module.exports = nextConfig


### PR DESCRIPTION
## Summary

This PR implements a multi-layered caching strategy to prevent Google API rate limiting (429 errors) when loading user profile images.

## Problem
- Frontend was hitting Google's rate limits when fetching user profile pictures
- This resulted in 429 errors and missing/broken avatar images

## Solution
1. **Extended cache duration**: Changed from daily to weekly cache keys for Google avatars, reducing the frequency of cache busting
2. **Robust avatar component**: Created `CachedAvatarImg` component with:
   - Error handling and automatic fallback to user initials
   - Loading states for better UX
   - Lazy loading support
3. **Browser caching**: Configured Next.js to set proper cache headers (7 days) for avatar images
4. **Optional proxy API**: Added an API route that can proxy avatar requests with server-side caching (can be enabled if rate limiting persists)

## Technical Details
- Updated `getCachedAvatarUrl` utility to use weekly cache keys for Google URLs
- Created `CachedAvatar` and `CachedAvatarImg` components for better error handling
- Added Next.js configuration for image domains and cache headers
- Implemented optional proxy API with in-memory caching

## Testing
- The avatar component gracefully falls back to initials if the image fails to load
- Cache keys change weekly instead of daily, significantly reducing API calls
- Browser caches avatar images for 7 days

This should resolve the 429 rate limiting errors and provide a better user experience even when rate limits are encountered.