### PR TITLE
Fix activity log enum value mappings

### DIFF
--- a/cmd/automation-engine/internal/processing/worker.go
+++ b/cmd/automation-engine/internal/processing/worker.go
@@ -610,11 +610,8 @@ func (w *Worker) persistProcessingResult(ctx context.Context, userID int, jobTyp
 		}
 	}
 
-	// Determine processing scope based on job type
-	processingScope := "scheduled"
-	if jobType == "manual_sync" {
-		processingScope = "manual"
-	}
+	// Determine processing scope - both manual and scheduled process multiple days
+	processingScope := "date_range"
 
 	// Prepare error message if needed
 	var errorMessage *string
@@ -625,11 +622,20 @@ func (w *Worker) persistProcessingResult(ctx context.Context, userID int, jobTyp
 	// Calculate processing duration
 	processingDurationMs := int(result.ProcessingTime.Milliseconds())
 
+	// Map job type to processing type enum value
+	processingType := "daily" // default
+	switch jobType {
+	case "manual_sync":
+		processingType = "manual"
+	case "scheduled_sync":
+		processingType = "daily"
+	}
+
 	// Create activity log entry with full schema
 	logEntry := &database.ActivityLog{
 		UserID:               userID,
 		ProcessingDate:       processingDateOnly,
-		ProcessingType:       jobType,
+		ProcessingType:       processingType,
 		ProcessingScope:      processingScope,
 		Status:               status,
 		ActivitiesFound:      result.ActivitiesCount,


### PR DESCRIPTION
## Summary
- Fixed PostgreSQL enum errors when persisting activity logs
- Corrected job type to processing type mapping
- Fixed processing scope values

## Changes
1. **Processing Type Mapping**: Map job types to correct enum values
   - `"manual_sync"` → `"manual"`
   - `"scheduled_sync"` → `"daily"`

2. **Processing Scope**: Set to `"date_range"` for both job types (was incorrectly using `"manual"`/`"scheduled"`)

## Test plan
- [ ] Deploy changes
- [ ] Trigger a manual sync and verify no PostgreSQL enum errors
- [ ] Verify scheduled sync also works without errors
- [ ] Check activity_logs table has correct enum values

🤖 Generated with [Claude Code](https://claude.ai/code)