### PR TITLE
fix: change VPC egress to private-ranges-only to fix Strava OAuth timeout

### DIFF
--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -148,7 +148,7 @@ resource "google_cloud_run_service" "backend_api" {
         "autoscaling.knative.dev/maxScale"      = "100"
         "run.googleapis.com/cloudsql-instances" = google_sql_database_instance.main.connection_name
         "run.googleapis.com/vpc-access-connector" = google_vpc_access_connector.main.id
-        "run.googleapis.com/vpc-access-egress"     = "all-traffic"
+        "run.googleapis.com/vpc-access-egress"     = "private-ranges-only"
         "run.googleapis.com/deletion-protection" = "true"
       }
     }
@@ -307,7 +307,7 @@ resource "google_cloud_run_service" "automation_engine" {
         "autoscaling.knative.dev/maxScale"      = "10"
         "run.googleapis.com/cloudsql-instances" = google_sql_database_instance.main.connection_name
         "run.googleapis.com/vpc-access-connector" = google_vpc_access_connector.main.id
-        "run.googleapis.com/vpc-access-egress"     = "all-traffic"
+        "run.googleapis.com/vpc-access-egress"     = "private-ranges-only"
         "run.googleapis.com/deletion-protection" = "true"
       }
     }
@@ -459,7 +459,7 @@ resource "google_cloud_run_service" "notification_service" {
         "autoscaling.knative.dev/maxScale"      = "5"
         "run.googleapis.com/cloudsql-instances" = google_sql_database_instance.main.connection_name
         "run.googleapis.com/vpc-access-connector" = google_vpc_access_connector.main.id
-        "run.googleapis.com/vpc-access-egress"     = "all-traffic"
+        "run.googleapis.com/vpc-access-egress"     = "private-ranges-only"
         "run.googleapis.com/deletion-protection" = "true"
       }
     }


### PR DESCRIPTION
## Summary
Fixed the Strava OAuth timeout issue in staging environment by correcting the VPC network configuration.

## Problem
The staging environment was experiencing consistent 60-second timeouts when connecting to Strava's OAuth endpoints. Investigation revealed that:
- Cloud Run services were configured with `vpc-access-egress = "all-traffic"`
- This routes ALL traffic (including internet-bound) through the VPC connector
- The VPC had no NAT gateway configured
- Result: All outbound internet traffic was blocked, causing timeouts

## Solution
Changed `vpc-access-egress` from `"all-traffic"` to `"private-ranges-only"` in the Terraform configuration for all three Cloud Run services.

This means:
- Private traffic (Cloud SQL, Redis) still routes through VPC ✅
- Internet traffic (Strava, Google APIs) uses Cloud Run's default egress ✅
- No additional infrastructure (NAT gateway) needed ✅
- Fixes the OAuth timeout issue ✅

## Testing
After applying this change in staging:
- Strava OAuth flow should complete successfully without timeouts
- Cloud SQL and Redis connections continue to work through VPC
- No additional costs for NAT gateway infrastructure

## Files Changed
- `terraform/services.tf` - Updated vpc-access-egress for backend-api, automation-engine, and notification-service

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated network egress settings for multiple services to restrict traffic to private ranges only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->