### PR TITLE
Fix: Manual sync not processing current day due to timezone issue

### DIFF
--- a/cmd/automation-engine/internal/processing/processing_service.go
+++ b/cmd/automation-engine/internal/processing/processing_service.go
@@ -681,6 +681,15 @@ func (s *ProcessingService) FetchAllTrainingPlanEntries(ctx context.Context, con
 		"start_date", startDate.Format("2006-01-02"),
 		"end_date", endDate.Format("2006-01-02"),
 		"spreadsheet_id", config.SpreadsheetID)
+	
+	// Load user's timezone for date parsing
+	location, err := time.LoadLocation(config.Timezone)
+	if err != nil {
+		s.logger.Error("Invalid timezone",
+			"timezone", config.Timezone,
+			"error", err)
+		return nil, fmt.Errorf("invalid timezone %s: %w", config.Timezone, err)
+	}
 
 	// Calculate the range more intelligently based on the year
 	// Since this is a yearly plan, we can estimate the row range
@@ -767,7 +776,7 @@ func (s *ProcessingService) FetchAllTrainingPlanEntries(ctx context.Context, con
 			continue
 		}
 
-		entry := s.parseTrainingPlanRow(row, actualRow)
+		entry := s.parseTrainingPlanRow(row, actualRow, location)
 		if entry != nil && !entry.Date.IsZero() {
 			// Set IsProcessed based on bold status of description column (J)
 			entry.IsProcessed = boldStatuses[actualRow]
@@ -908,7 +917,7 @@ func (s *ProcessingService) fetchBoldStatuses(ctx context.Context, spreadsheetID
 }
 
 // parseTrainingPlanRow parses a spreadsheet row into a TrainingPlanEntry
-func (s *ProcessingService) parseTrainingPlanRow(row []interface{}, rowNumber int) *TrainingPlanEntry {
+func (s *ProcessingService) parseTrainingPlanRow(row []interface{}, rowNumber int, location *time.Location) *TrainingPlanEntry {
 	entry := &TrainingPlanEntry{
 		Row: rowNumber,
 	}
@@ -944,7 +953,8 @@ func (s *ProcessingService) parseTrainingPlanRow(row []interface{}, rowNumber in
 	// Parse date (Column A - index 0)
 	// Date format is always non-zero-padded: "1.5.2025", "22.6.2025", etc.
 	if dateStr := getString(0); dateStr != "" {
-		parsedDate, err := time.Parse("2.1.2006", dateStr)
+		// Parse in the user's timezone to match the date range filtering
+		parsedDate, err := time.ParseInLocation("2.1.2006", dateStr, location)
 		if err != nil {
 			s.logger.Warn("Failed to parse date from training plan",
 				"date_string", dateStr,
@@ -956,7 +966,8 @@ func (s *ProcessingService) parseTrainingPlanRow(row []interface{}, rowNumber in
 				"date_string", dateStr,
 				"parsed_date", parsedDate.Format("2006-01-02"),
 				"row", rowNumber,
-				"is_july_18", parsedDate.Format("2006-01-02") == "2025-07-18")
+				"is_july_18", parsedDate.Format("2006-01-02") == "2025-07-18",
+				"timezone", location.String())
 			entry.Date = parsedDate
 		}
 	}

--- a/cmd/automation-engine/internal/processing/processing_service.go
+++ b/cmd/automation-engine/internal/processing/processing_service.go
@@ -709,6 +709,26 @@ func (s *ProcessingService) FetchAllTrainingPlanEntries(ctx context.Context, con
 		return nil, fmt.Errorf("failed to read training plan: %w", err)
 	}
 
+	// Debug logging for fetched rows
+	s.logger.Debug("Raw rows fetched from spreadsheet",
+		"user_id", config.UserID,
+		"rows_count", len(rows),
+		"range", rangeSpec,
+		"start_row", startRow,
+		"end_row", endRow,
+		"first_row_data", func() string {
+			if len(rows) > 0 && len(rows[0]) > 0 {
+				return fmt.Sprintf("%v", rows[0][0])
+			}
+			return "no data"
+		}(),
+		"last_row_data", func() string {
+			if len(rows) > 0 && len(rows[len(rows)-1]) > 0 {
+				return fmt.Sprintf("%v", rows[len(rows)-1][0])
+			}
+			return "no data"
+		}())
+
 	// We also need to fetch cell formatting to check for bold text
 	// This requires a separate API call to get formatting info
 	boldStatuses, err := s.fetchBoldStatuses(ctx, config.SpreadsheetID, rangeSpec, startRow, len(rows))
@@ -724,11 +744,29 @@ func (s *ProcessingService) FetchAllTrainingPlanEntries(ctx context.Context, con
 	cache := make(TrainingPlanCache)
 
 	for rowIndex, row := range rows {
+		actualRow := startRow + rowIndex
+		
+		// Log the raw row data
+		s.logger.Debug("Processing spreadsheet row",
+			"row_index", rowIndex,
+			"actual_row", actualRow,
+			"expected_row_for_july_18", 200,
+			"row_data", func() string {
+				if len(row) > 0 {
+					return fmt.Sprintf("Date: %v, Type: %v", row[0], func() string {
+						if len(row) > 3 {
+							return fmt.Sprintf("%v", row[3])
+						}
+						return "N/A"
+					}())
+				}
+				return "empty row"
+			}())
+		
 		if len(row) == 0 {
 			continue
 		}
 
-		actualRow := startRow + rowIndex
 		entry := s.parseTrainingPlanRow(row, actualRow)
 		if entry != nil && !entry.Date.IsZero() {
 			// Set IsProcessed based on bold status of description column (J)
@@ -737,6 +775,12 @@ func (s *ProcessingService) FetchAllTrainingPlanEntries(ctx context.Context, con
 			// Store in cache with normalized date key (YYYY-MM-DD)
 			dateKey := entry.Date.Format("2006-01-02")
 			cache[dateKey] = entry
+			
+			s.logger.Debug("Added entry to cache",
+				"date_key", dateKey,
+				"row", actualRow,
+				"is_processed", entry.IsProcessed,
+				"is_july_18", dateKey == "2025-07-18")
 		}
 	}
 
@@ -745,12 +789,36 @@ func (s *ProcessingService) FetchAllTrainingPlanEntries(ctx context.Context, con
 		"entries_found", len(cache),
 		"date_range", fmt.Sprintf("%s to %s", startDate.Format("2006-01-02"), endDate.Format("2006-01-02")))
 
+	// Log cache before filtering
+	s.logger.Debug("Cache before filtering",
+		"total_entries", len(cache),
+		"date_range", fmt.Sprintf("%s to %s", startDate.Format("2006-01-02"), endDate.Format("2006-01-02")),
+		"cache_dates", func() []string {
+			dates := make([]string, 0, len(cache))
+			for dateKey := range cache {
+				dates = append(dates, dateKey)
+			}
+			sort.Strings(dates)
+			return dates
+		}())
+
 	// Filter cache to only include entries within the requested date range
 	// This ensures we only process the exact date range requested, even though
 	// we fetched extra rows as a buffer for safety
 	filteredCache := make(TrainingPlanCache)
 	for dateKey, entry := range cache {
-		if !entry.Date.Before(startDate) && !entry.Date.After(endDate) {
+		includeEntry := !entry.Date.Before(startDate) && !entry.Date.After(endDate)
+		s.logger.Debug("Filtering cache entry",
+			"date_key", dateKey,
+			"entry_date", entry.Date.Format("2006-01-02"),
+			"start_date", startDate.Format("2006-01-02"),
+			"end_date", endDate.Format("2006-01-02"),
+			"before_start", entry.Date.Before(startDate),
+			"after_end", entry.Date.After(endDate),
+			"included", includeEntry,
+			"row", entry.Row)
+		
+		if includeEntry {
 			filteredCache[dateKey] = entry
 		}
 	}
@@ -761,6 +829,18 @@ func (s *ProcessingService) FetchAllTrainingPlanEntries(ctx context.Context, con
 		"filtered_count", len(filteredCache),
 		"start_date", startDate.Format("2006-01-02"),
 		"end_date", endDate.Format("2006-01-02"))
+	
+	// Log final cache state
+	s.logger.Debug("Final filtered cache details",
+		"filtered_dates", func() []string {
+			dates := make([]string, 0, len(filteredCache))
+			for dateKey := range filteredCache {
+				dates = append(dates, dateKey)
+			}
+			sort.Strings(dates)
+			return dates
+		}(),
+		"has_july_18", filteredCache["2025-07-18"] != nil)
 
 	return filteredCache, nil
 }
@@ -869,8 +949,14 @@ func (s *ProcessingService) parseTrainingPlanRow(row []interface{}, rowNumber in
 			s.logger.Warn("Failed to parse date from training plan",
 				"date_string", dateStr,
 				"row", rowNumber,
-				"error", err)
+				"error", err,
+				"expected_format", "2.1.2006")
 		} else {
+			s.logger.Debug("Successfully parsed date",
+				"date_string", dateStr,
+				"parsed_date", parsedDate.Format("2006-01-02"),
+				"row", rowNumber,
+				"is_july_18", parsedDate.Format("2006-01-02") == "2025-07-18")
 			entry.Date = parsedDate
 		}
 	}

--- a/cmd/automation-engine/internal/processing/processing_service_test.go
+++ b/cmd/automation-engine/internal/processing/processing_service_test.go
@@ -103,6 +103,13 @@ func createTestConfig(userID int, timezone string) *automation.ProcessingConfig 
 	}
 }
 
+// Helper to parse dates in a specific timezone
+func parseTestDate(dateStr string, timezone string) time.Time {
+	location, _ := time.LoadLocation(timezone)
+	date, _ := time.ParseInLocation("2006-01-02", dateStr, location)
+	return date
+}
+
 // Test fetchAllTrainingPlanEntries with successful data
 func TestFetchAllTrainingPlanEntries_Success(t *testing.T) {
 	mockStrava := &MockStravaClient{}
@@ -117,8 +124,8 @@ func TestFetchAllTrainingPlanEntries_Success(t *testing.T) {
 	service := NewProcessingService(mockStrava, mockSheets, nil, createTestLogger())
 	config := createTestConfig(1, "Europe/Sofia")
 
-	startDate, _ := time.Parse("2006-01-02", "2025-05-01")
-	endDate, _ := time.Parse("2006-01-02", "2025-05-03")
+	startDate := parseTestDate("2025-05-01", "Europe/Sofia")
+	endDate := parseTestDate("2025-05-03", "Europe/Sofia")
 
 	cache, err := service.FetchAllTrainingPlanEntries(context.Background(), config, startDate, endDate)
 
@@ -159,8 +166,8 @@ func TestFetchAllTrainingPlanEntries_SmartRangeCalculation(t *testing.T) {
 	config := createTestConfig(1, "Europe/Sofia")
 
 	// Test mid-year dates (June 22-25)
-	startDate, _ := time.Parse("2006-01-02", "2025-06-22")
-	endDate, _ := time.Parse("2006-01-02", "2025-06-25")
+	startDate := parseTestDate("2025-06-22", "Europe/Sofia")
+	endDate := parseTestDate("2025-06-25", "Europe/Sofia")
 
 	_, _ = service.FetchAllTrainingPlanEntries(context.Background(), config, startDate, endDate)
 
@@ -187,7 +194,8 @@ func TestParseTrainingPlanRow_StandardDateFormat(t *testing.T) {
 
 	for _, tc := range testCases {
 		row := []interface{}{tc.dateStr, "", "", "Бягане", "10", "01:00:00", "", "", "5", "Test"}
-		entry := service.parseTrainingPlanRow(row, 2)
+		location, _ := time.LoadLocation("UTC")
+		entry := service.parseTrainingPlanRow(row, 2, location)
 
 		if entry.Date.Format("2006-01-02") != tc.expectedDate {
 			t.Errorf("For date string '%s', expected %s, got %s",
@@ -202,7 +210,8 @@ func TestParseTrainingPlanRow_InvalidDate(t *testing.T) {
 
 	// Invalid date format
 	row := []interface{}{"32.13.2025", "", "", "Бягане", "10", "01:00:00", "", "", "5", "Test"}
-	entry := service.parseTrainingPlanRow(row, 2)
+	location, _ := time.LoadLocation("UTC")
+	entry := service.parseTrainingPlanRow(row, 2, location)
 
 	if !entry.Date.IsZero() {
 		t.Error("Expected zero date for invalid date string")
@@ -219,7 +228,7 @@ func TestProcessSingleDay_NoTrainingPlan(t *testing.T) {
 	service := NewProcessingService(mockStrava, mockSheets, nil, createTestLogger())
 	config := createTestConfig(1, "Europe/Sofia")
 
-	date, _ := time.Parse("2006-01-02", "2025-05-01")
+	date := parseTestDate("2025-05-01", "Europe/Sofia")
 	cache := make(TrainingPlanCache) // Empty cache
 
 	activitiesCache := make(StravaActivitiesCache)
@@ -246,7 +255,7 @@ func TestProcessSingleDay_AlreadyProcessed(t *testing.T) {
 	service := NewProcessingService(mockStrava, mockSheets, nil, createTestLogger())
 	config := createTestConfig(1, "Europe/Sofia")
 
-	date, _ := time.Parse("2006-01-02", "2025-05-01")
+	date := parseTestDate("2025-05-01", "Europe/Sofia")
 	cache := TrainingPlanCache{
 		"2025-05-01": &TrainingPlanEntry{
 			Date:         date,
@@ -274,7 +283,7 @@ func TestProcessSingleDay_AlreadyProcessed(t *testing.T) {
 
 // Test rest day with activity (RPE = 2 special case)
 func TestProcessSingleDay_RestDayWithActivity(t *testing.T) {
-	date, _ := time.Parse("2006-01-02", "2025-05-01")
+	date := parseTestDate("2025-05-01", "Europe/Sofia")
 	dateKey := date.Format("2006-01-02")
 
 	mockStrava := &MockStravaClient{
@@ -325,7 +334,7 @@ func TestProcessSingleDay_RestDayWithActivity(t *testing.T) {
 
 // Test scheduled run with no activity
 func TestProcessSingleDay_ScheduledRunNoActivity(t *testing.T) {
-	date, _ := time.Parse("2006-01-02", "2025-05-01")
+	date := parseTestDate("2025-05-01", "Europe/Sofia")
 	dateKey := date.Format("2006-01-02")
 
 	mockStrava := &MockStravaClient{
@@ -387,8 +396,8 @@ func TestProcessing_SingleAPICall(t *testing.T) {
 	config := createTestConfig(1, "Europe/Sofia")
 
 	// Test processing multiple days with cache
-	startDate, _ := time.Parse("2006-01-02", "2025-05-01")
-	endDate, _ := time.Parse("2006-01-02", "2025-05-03")
+	startDate := parseTestDate("2025-05-01", "Europe/Sofia")
+	endDate := parseTestDate("2025-05-03", "Europe/Sofia")
 
 	// Fetch cache once
 	cache, err := service.FetchAllTrainingPlanEntries(context.Background(), config, startDate, endDate)
@@ -425,8 +434,8 @@ func TestFetchAllTrainingPlanEntries_EmptySpreadsheet(t *testing.T) {
 	service := NewProcessingService(mockStrava, mockSheets, nil, createTestLogger())
 	config := createTestConfig(1, "Europe/Sofia")
 
-	startDate, _ := time.Parse("2006-01-02", "2025-05-01")
-	endDate, _ := time.Parse("2006-01-02", "2025-05-03")
+	startDate := parseTestDate("2025-05-01", "Europe/Sofia")
+	endDate := parseTestDate("2025-05-03", "Europe/Sofia")
 
 	cache, err := service.FetchAllTrainingPlanEntries(context.Background(), config, startDate, endDate)
 
@@ -561,8 +570,8 @@ func TestFetchAllTrainingPlanEntries_YearBoundary(t *testing.T) {
 	config := createTestConfig(1, "Europe/Sofia")
 
 	// Test crossing year boundary
-	startDate, _ := time.Parse("2006-01-02", "2024-12-30")
-	endDate, _ := time.Parse("2006-01-02", "2025-01-01")
+	startDate := parseTestDate("2024-12-30", "Europe/Sofia")
+	endDate := parseTestDate("2025-01-01", "Europe/Sofia")
 
 	cache, err := service.FetchAllTrainingPlanEntries(context.Background(), config, startDate, endDate)
 
@@ -650,8 +659,8 @@ func TestFetchAllTrainingPlanEntries_APIError(t *testing.T) {
 	service := NewProcessingService(mockStrava, mockSheets, nil, createTestLogger())
 	config := createTestConfig(1, "Europe/Sofia")
 
-	startDate, _ := time.Parse("2006-01-02", "2025-05-01")
-	endDate, _ := time.Parse("2006-01-02", "2025-05-03")
+	startDate := parseTestDate("2025-05-01", "Europe/Sofia")
+	endDate := parseTestDate("2025-05-03", "Europe/Sofia")
 
 	_, err := service.FetchAllTrainingPlanEntries(context.Background(), config, startDate, endDate)
 
@@ -666,7 +675,7 @@ func TestFetchAllTrainingPlanEntries_APIError(t *testing.T) {
 
 // Test that spreadsheet updates are properly prepared
 func TestSpreadsheetUpdatePreparation(t *testing.T) {
-	date, _ := time.Parse("2006-01-02", "2025-05-01")
+	date := parseTestDate("2025-05-01", "Europe/Sofia")
 	dateKey := date.Format("2006-01-02")
 
 	mockStrava := &MockStravaClient{


### PR DESCRIPTION
## Summary
- Fixed manual sync not processing the current day (July 18th) after optimization changes
- Root cause: Training plan dates were parsed in UTC but filtered using user's timezone
- Solution: Parse all dates in user's timezone using `time.ParseInLocation()`

## Changes
1. Added comprehensive logging to debug the filtering issue
2. Fixed timezone parsing in `FetchAllTrainingPlanEntries` to use user's timezone
3. Updated all test date parsing to use timezone-aware dates
4. Verified that current day is only processed in manual sync, not scheduled sync

## Test plan
- [x] All existing tests pass with timezone-aware implementation
- [x] Manual sync now correctly processes current day (July 18th)
- [x] Verified scheduled sync only processes yesterday + 7-day lookback
- [x] Verified manual sync processes today + yesterday + 7-day lookback

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved date handling to be timezone-aware when processing training plan entries.
  * Enhanced debug logging for greater transparency during training plan entry processing.

* **Tests**
  * Updated all date parsing in tests to use timezone-aware parsing.
  * Added a helper function for parsing test dates with timezone support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->