### PR TITLE
Add automation and email notification toggles (Issue #76)

### DIFF
--- a/cmd/backend-api/main.go
+++ b/cmd/backend-api/main.go
@@ -152,6 +152,7 @@ func main() {
 	// Initialize services
 	sheetsService := services.NewSheetsService(userRepository, log)
 	configService := services.NewConfigService(userRepository, sheetsService, log)
+	settingsService := services.NewSettingsService(userRepository, log)
 
 	// Initialize sync service (only if Redis is available)
 	var syncService *services.SyncService
@@ -195,6 +196,12 @@ func main() {
 	configHandler := handlers.NewConfigHandler(
 		configService,
 		log.WithContext("component", "config_handler"),
+	)
+
+	settingsHandler := handlers.NewSettingsHandler(
+		settingsService,
+		userRepository,
+		log.WithContext("component", "settings_handler"),
 	)
 
 	// Initialize sync handler (only if sync service is available)
@@ -286,6 +293,9 @@ func main() {
 			r.Delete("/spreadsheet", configHandler.ClearSpreadsheet) // Clear spreadsheet configuration
 			r.Post("/timezone", configHandler.SetTimezone)           // Set user timezone
 		})
+
+		// Settings routes
+		r.Put("/settings", settingsHandler.UpdateSettings) // Update user settings (automation, notifications)
 
 		// Sync routes (only if sync service is available)
 		if syncHandler != nil {

--- a/internal/pkg/api/handlers/settings.go
+++ b/internal/pkg/api/handlers/settings.go
@@ -1,0 +1,92 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/Perseverance/the-academy-sync-claude/internal/pkg/api/middleware"
+	"github.com/Perseverance/the-academy-sync-claude/internal/pkg/database"
+	"github.com/Perseverance/the-academy-sync-claude/internal/pkg/logger"
+	"github.com/Perseverance/the-academy-sync-claude/internal/pkg/services"
+)
+
+// SettingsHandler handles user settings endpoints
+type SettingsHandler struct {
+	settingsService *services.SettingsService
+	userRepository  *database.UserRepository
+	logger          *logger.Logger
+}
+
+// NewSettingsHandler creates a new settings handler
+func NewSettingsHandler(settingsService *services.SettingsService, userRepository *database.UserRepository, logger *logger.Logger) *SettingsHandler {
+	return &SettingsHandler{
+		settingsService: settingsService,
+		userRepository:  userRepository,
+		logger:          logger,
+	}
+}
+
+// UpdateSettingsRequest represents the request body for updating settings
+type UpdateSettingsRequest struct {
+	AutomationEnabled         bool `json:"automation_enabled"`
+	EmailNotificationsEnabled bool `json:"email_notifications_enabled"`
+}
+
+// UpdateSettings handles PUT /api/settings
+func (h *SettingsHandler) UpdateSettings(w http.ResponseWriter, r *http.Request) {
+	userID, ok := middleware.GetUserIDFromContext(r.Context())
+	if !ok {
+		h.logger.Error("User ID not found in context")
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	// Parse request body
+	var req UpdateSettingsRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		h.logger.Error("Failed to decode request body", "error", err)
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	h.logger.Info("Updating user settings",
+		"user_id", userID,
+		"automation_enabled", req.AutomationEnabled,
+		"email_notifications_enabled", req.EmailNotificationsEnabled)
+
+	// Update settings with validation
+	if err := h.settingsService.UpdateUserSettings(r.Context(), userID, req.AutomationEnabled, req.EmailNotificationsEnabled); err != nil {
+		// Check if it's a validation error
+		switch err.Error() {
+		case "Strava connection required to enable automation":
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		case "Google Sheets spreadsheet required to enable automation":
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		default:
+			h.logger.Error("Failed to update user settings", "error", err, "user_id", userID)
+			http.Error(w, "Failed to update settings", http.StatusInternalServerError)
+			return
+		}
+	}
+
+	// Fetch updated user data to return
+	user, err := h.userRepository.GetUserByID(r.Context(), userID)
+	if err != nil {
+		h.logger.Error("Failed to fetch updated user data", "error", err, "user_id", userID)
+		http.Error(w, "Failed to fetch updated data", http.StatusInternalServerError)
+		return
+	}
+
+	// Return updated public user data
+	publicUser := user.ToPublicUser()
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(publicUser); err != nil {
+		h.logger.Error("Failed to encode response", "error", err)
+		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+		return
+	}
+
+	h.logger.Info("Successfully updated user settings", "user_id", userID)
+}

--- a/internal/pkg/database/user_repository.go
+++ b/internal/pkg/database/user_repository.go
@@ -3,6 +3,7 @@ package database
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"time"
 
 	"github.com/Perseverance/the-academy-sync-claude/internal/pkg/auth"
@@ -659,4 +660,31 @@ func (r *UserRepository) GetUsersInProcessingWindow(ctx context.Context) ([]int,
 	}
 
 	return userIDs, nil
+}
+
+// UpdateUserSettings updates the user's settings (automation_enabled and email_notifications_enabled)
+func (ur *UserRepository) UpdateUserSettings(ctx context.Context, userID int, automationEnabled, emailNotificationsEnabled bool) error {
+	query := `
+		UPDATE users 
+		SET 
+			automation_enabled = $2,
+			email_notifications_enabled = $3,
+			updated_at = NOW()
+		WHERE id = $1`
+	
+	result, err := ur.db.Exec(query, userID, automationEnabled, emailNotificationsEnabled)
+	if err != nil {
+		return err
+	}
+	
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	
+	if rowsAffected == 0 {
+		return fmt.Errorf("user with ID %d not found", userID)
+	}
+	
+	return nil
 }

--- a/internal/pkg/services/settings_service.go
+++ b/internal/pkg/services/settings_service.go
@@ -1,0 +1,73 @@
+package services
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Perseverance/the-academy-sync-claude/internal/pkg/database"
+	"github.com/Perseverance/the-academy-sync-claude/internal/pkg/logger"
+)
+
+// SettingsService handles user settings operations
+type SettingsService struct {
+	userRepo *database.UserRepository
+	logger   *logger.Logger
+}
+
+// NewSettingsService creates a new settings service
+func NewSettingsService(userRepo *database.UserRepository, logger *logger.Logger) *SettingsService {
+	return &SettingsService{
+		userRepo: userRepo,
+		logger:   logger,
+	}
+}
+
+// UpdateUserSettings updates the user's settings with validation
+func (s *SettingsService) UpdateUserSettings(ctx context.Context, userID int, automationEnabled, emailNotificationsEnabled bool) error {
+	// If trying to enable automation, validate requirements
+	if automationEnabled {
+		// Fetch user to check requirements
+		user, err := s.userRepo.GetUserByID(ctx, userID)
+		if err != nil {
+			s.logger.Error("Failed to fetch user for validation", "error", err, "user_id", userID)
+			return fmt.Errorf("failed to fetch user: %w", err)
+		}
+
+		// Check if user has Strava connection
+		if len(user.StravaRefreshToken) == 0 {
+			s.logger.Info("User tried to enable automation without Strava connection", "user_id", userID)
+			return fmt.Errorf("Strava connection required to enable automation")
+		}
+
+		// Check if user has spreadsheet configured
+		if user.SpreadsheetID == nil || *user.SpreadsheetID == "" {
+			s.logger.Info("User tried to enable automation without spreadsheet", "user_id", userID)
+			return fmt.Errorf("Google Sheets spreadsheet required to enable automation")
+		}
+
+		// Timezone is already enforced as NOT NULL with default 'UTC' in database
+		s.logger.Info("User meets all requirements for automation", 
+			"user_id", userID,
+			"has_strava", true,
+			"has_spreadsheet", true,
+			"timezone", user.Timezone)
+	}
+
+	// Update the settings
+	err := s.userRepo.UpdateUserSettings(ctx, userID, automationEnabled, emailNotificationsEnabled)
+	if err != nil {
+		s.logger.Error("Failed to update user settings", 
+			"error", err, 
+			"user_id", userID,
+			"automation_enabled", automationEnabled,
+			"email_notifications_enabled", emailNotificationsEnabled)
+		return fmt.Errorf("failed to update settings: %w", err)
+	}
+
+	s.logger.Info("Successfully updated user settings",
+		"user_id", userID,
+		"automation_enabled", automationEnabled,
+		"email_notifications_enabled", emailNotificationsEnabled)
+
+	return nil
+}

--- a/web/components/dashboard-page.tsx
+++ b/web/components/dashboard-page.tsx
@@ -4,6 +4,7 @@ import { useAppState } from "@/context/app-state-provider"
 import { ConnectionCard } from "@/components/connection-card"
 import { SpreadsheetCard } from "@/components/spreadsheet-card"
 import { ManualSyncCard } from "@/components/manual-sync-card"
+import { SettingsCard } from "@/components/settings-card"
 import { ActivityLog } from "@/components/activity-log"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { GoogleLogo } from "@/components/icons/google-logo"
@@ -116,6 +117,9 @@ export function DashboardPage() {
 
             {/* Manual Sync Card - Spans 1 column */}
             <ManualSyncCard status={state.manualSyncStatus} onSync={actions.triggerManualSync} />
+
+            {/* Settings Card - Spans 1 column */}
+            <SettingsCard />
 
             {/* Activity Log - Spans full width on its row or multiple columns */}
             <div className="md:col-span-2 lg:col-span-3">

--- a/web/components/settings-card.tsx
+++ b/web/components/settings-card.tsx
@@ -1,0 +1,119 @@
+"use client"
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Label } from "@/components/ui/label"
+import { Switch } from "@/components/ui/switch"
+import { Settings, Mail, Bot } from "lucide-react"
+import { useAppState } from "@/context/app-state-provider"
+import { useState } from "react"
+import { toast } from "sonner"
+
+export function SettingsCard() {
+  const { state, actions } = useAppState()
+  const [isUpdating, setIsUpdating] = useState(false)
+
+  if (!state.user) return null
+
+  const canEnableAutomation = state.user.has_strava_connection && state.user.has_sheets_connection
+
+  const handleAutomationToggle = async (checked: boolean) => {
+    if (!canEnableAutomation && checked) {
+      toast.error("Cannot enable automation", {
+        description: "Please connect both Strava and Google Sheets first"
+      })
+      return
+    }
+
+    setIsUpdating(true)
+    try {
+      await actions.updateUserSettings({
+        automation_enabled: checked,
+        email_notifications_enabled: state.user.email_notifications_enabled
+      })
+      toast.success(checked ? "Automation enabled" : "Automation disabled")
+    } catch (error: any) {
+      toast.error("Failed to update settings", {
+        description: error.message || "Please try again"
+      })
+    } finally {
+      setIsUpdating(false)
+    }
+  }
+
+  const handleEmailToggle = async (checked: boolean) => {
+    setIsUpdating(true)
+    try {
+      await actions.updateUserSettings({
+        automation_enabled: state.user.automation_enabled,
+        email_notifications_enabled: checked
+      })
+      toast.success(checked ? "Email notifications enabled" : "Email notifications disabled")
+    } catch (error: any) {
+      toast.error("Failed to update settings", {
+        description: error.message || "Please try again"
+      })
+    } finally {
+      setIsUpdating(false)
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Settings className="h-5 w-5" />
+          Settings
+        </CardTitle>
+        <CardDescription>
+          Manage your automation and notification preferences
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="flex items-center justify-between space-x-2">
+          <div className="flex items-center space-x-3">
+            <Bot className="h-5 w-5 text-muted-foreground" />
+            <div className="space-y-1">
+              <Label 
+                htmlFor="automation-toggle" 
+                className={!canEnableAutomation ? "text-muted-foreground" : ""}
+              >
+                Daily Automation
+              </Label>
+              <p className="text-sm text-muted-foreground">
+                {canEnableAutomation 
+                  ? "Automatically sync activities to your spreadsheet daily"
+                  : "Connect Strava and Google Sheets to enable automation"}
+              </p>
+            </div>
+          </div>
+          <Switch
+            id="automation-toggle"
+            checked={state.user.automation_enabled}
+            onCheckedChange={handleAutomationToggle}
+            disabled={!canEnableAutomation || isUpdating}
+          />
+        </div>
+
+        <div className="flex items-center justify-between space-x-2">
+          <div className="flex items-center space-x-3">
+            <Mail className="h-5 w-5 text-muted-foreground" />
+            <div className="space-y-1">
+              <Label htmlFor="email-toggle">
+                Email Notifications
+              </Label>
+              <p className="text-sm text-muted-foreground">
+                Receive email updates about sync status
+              </p>
+            </div>
+          </div>
+          <Switch
+            id="email-toggle"
+            checked={state.user.email_notifications_enabled}
+            onCheckedChange={handleEmailToggle}
+            disabled={isUpdating}
+          />
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/web/context/app-state-provider.tsx
+++ b/web/context/app-state-provider.tsx
@@ -8,6 +8,7 @@ import { authService, type User } from "@/services/auth"
 import { stravaService } from "@/services/strava"
 import { configService } from "@/services/config"
 import { syncService, SyncError } from "@/services/SyncService"
+import { settingsService } from "@/services/settings"
 import { useToast } from "@/hooks/use-toast"
 
 export type ServiceStatus = "Connected" | "NotConnected" | "ReauthorizationNeeded"
@@ -38,6 +39,7 @@ interface AppActions {
   changeSpreadsheet: () => void
   triggerManualSync: () => Promise<void>
   setGoogleStatus: (status: ServiceStatus) => void // For external updates if needed
+  updateUserSettings: (settings: { automation_enabled: boolean; email_notifications_enabled: boolean }) => Promise<void>
 }
 
 const AppStateContext = createContext<
@@ -393,6 +395,19 @@ export function AppStateProvider({ children }: { children: React.ReactNode }) {
     setState((s) => ({ ...s, googleStatus: status }))
   }
 
+  const updateUserSettings = async (settings: { automation_enabled: boolean; email_notifications_enabled: boolean }) => {
+    try {
+      const updatedUser = await settingsService.updateSettings(settings)
+      setState((s) => ({ ...s, user: updatedUser }))
+      
+      // Update sync status based on automation setting
+      updateServiceStatuses(updatedUser)
+    } catch (error: any) {
+      console.error('Failed to update settings:', error)
+      throw error
+    }
+  }
+
 
   // Remove the loading state after initial load
   useEffect(() => {
@@ -412,6 +427,7 @@ export function AppStateProvider({ children }: { children: React.ReactNode }) {
     changeSpreadsheet,
     triggerManualSync,
     setGoogleStatus,
+    updateUserSettings,
   }
 
   // Update timezone when window regains focus (in case user changed system timezone)

--- a/web/services/settings.ts
+++ b/web/services/settings.ts
@@ -1,0 +1,33 @@
+export interface UpdateSettingsRequest {
+  automation_enabled: boolean
+  email_notifications_enabled: boolean
+}
+
+class SettingsService {
+  private readonly baseURL: string
+
+  constructor() {
+    // Use environment variable for API URL, fallback to localhost
+    this.baseURL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080'
+  }
+
+  async updateSettings(settings: UpdateSettingsRequest) {
+    const response = await fetch(`${this.baseURL}/api/settings`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      credentials: 'include', // Important for cookie authentication
+      body: JSON.stringify(settings),
+    })
+
+    if (!response.ok) {
+      const errorText = await response.text()
+      throw new Error(errorText || 'Failed to update settings')
+    }
+
+    return response.json()
+  }
+}
+
+export const settingsService = new SettingsService()


### PR DESCRIPTION
## Summary
This PR implements user-facing toggles for controlling automation and email notifications, addressing Issue #76.

## Changes

### Backend
- Added `UpdateUserSettings` method to UserRepository for updating automation and email settings
- Created SettingsService with validation logic ensuring automation prerequisites are met
- Added PUT `/api/settings` endpoint with authentication
- Fixed import paths and logger type issues

### Frontend  
- Created Settings Card component with toggle switches for:
  - Daily Automation (disabled if Strava or Sheets not connected)
  - Email Notifications
- Integrated settings service for API calls
- Updated App State Provider to handle settings updates
- Added Settings Card to dashboard layout

## Validation
- Automation can only be enabled when user has:
  - Active Strava connection
  - Configured Google Sheets spreadsheet
- Clear error messages displayed when requirements not met
- Real-time UI updates after toggling settings

## Testing
The feature has been tested locally with docker-compose:
- ✅ Settings toggles appear in dashboard
- ✅ PUT requests to `/api/settings` succeed with 200 status
- ✅ Validation prevents enabling automation without prerequisites
- ✅ Both automation engine and notification service already honor these flags

## Related Issues
Closes #76

🤖 Generated with [Claude Code](https://claude.ai/code)