### PR TITLE
feat: prevent duplicate zero-activity logs for same calendar day

### DIFF
--- a/cmd/automation-engine/internal/processing/interfaces.go
+++ b/cmd/automation-engine/internal/processing/interfaces.go
@@ -29,4 +29,5 @@ type SheetsClient interface {
 // ActivityLogRepository defines the interface for activity log persistence
 type ActivityLogRepository interface {
 	CreateActivityLog(ctx context.Context, log *database.ActivityLog) error
+	GetSuccessfulLogForDate(ctx context.Context, userID int, processingDate time.Time, processingType string) (*database.ActivityLog, error)
 }

--- a/cmd/automation-engine/internal/processing/worker.go
+++ b/cmd/automation-engine/internal/processing/worker.go
@@ -923,6 +923,32 @@ func (w *Worker) persistProcessingResult(ctx context.Context, userID int, jobTyp
 		processingType = "daily"
 	}
 
+	// Check if we should skip creating a log entry
+	// Skip if: successful processing with zero activities found and an existing log exists for today
+	if status == "success" && result.TotalActivitiesFound == 0 {
+		// Use a separate context for the database check
+		checkCtx, checkCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer checkCancel()
+		
+		existingLog, err := w.activityLogRepo.GetSuccessfulLogForDate(checkCtx, userID, processingDateOnly, processingType)
+		if err != nil {
+			w.logger.Warn("Failed to check for existing activity log, will create new log",
+				"error", err,
+				"user_id", userID,
+				"processing_date", processingDateOnly,
+				"processing_type", processingType)
+		} else if existingLog != nil {
+			// Found existing successful log with zero activities for today, skip creating duplicate
+			w.logger.Debug("Skipping activity log creation - already have successful zero-activity log for today",
+				"user_id", userID,
+				"processing_date", processingDateOnly,
+				"processing_type", processingType,
+				"existing_log_id", existingLog.ID,
+				"existing_log_created_at", existingLog.CreatedAt)
+			return
+		}
+	}
+
 	// Create activity log entry with full schema
 	logEntry := &database.ActivityLog{
 		UserID:               userID,

--- a/cmd/automation-engine/internal/processing/worker_test.go
+++ b/cmd/automation-engine/internal/processing/worker_test.go
@@ -75,6 +75,14 @@ func (m *MockActivityLogRepo) CreateActivityLog(ctx context.Context, log *databa
 	return args.Error(0)
 }
 
+func (m *MockActivityLogRepo) GetSuccessfulLogForDate(ctx context.Context, userID int, processingDate time.Time, processingType string) (*database.ActivityLog, error) {
+	args := m.Called(ctx, userID, processingDate, processingType)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*database.ActivityLog), args.Error(1)
+}
+
 // MockQueueClient for testing
 type MockQueueClient struct {
 	mock.Mock

--- a/internal/pkg/database/activity_log_repository.go
+++ b/internal/pkg/database/activity_log_repository.go
@@ -397,3 +397,97 @@ func (r *ActivityLogRepository) GetRecentLogsByDateRange(ctx context.Context, us
 
 	return logs, nil
 }
+
+// GetSuccessfulLogForDate retrieves a successful activity log for a specific date with zero activities
+func (r *ActivityLogRepository) GetSuccessfulLogForDate(ctx context.Context, userID int, processingDate time.Time, processingType string) (*ActivityLog, error) {
+	query := `
+		SELECT 
+			id,
+			user_id,
+			processing_date,
+			processing_type,
+			processing_scope,
+			status,
+			activities_found,
+			activities_processed,
+			total_distance_meters,
+			total_duration_seconds,
+			spreadsheet_row,
+			spreadsheet_updated,
+			description_generated,
+			error_message,
+			warning_messages,
+			processing_started_at,
+			processing_completed_at,
+			processing_duration_ms,
+			metadata,
+			created_at
+		FROM activity_logs
+		WHERE user_id = $1 
+		  AND processing_date = $2
+		  AND processing_type = $3
+		  AND status = 'success'
+		  AND activities_found = 0
+		ORDER BY created_at DESC
+		LIMIT 1`
+
+	var log ActivityLog
+	var metadataJSON sql.NullString
+	var warningMessages pq.StringArray
+
+	err := r.db.QueryRowContext(ctx, query, userID, processingDate, processingType).Scan(
+		&log.ID,
+		&log.UserID,
+		&log.ProcessingDate,
+		&log.ProcessingType,
+		&log.ProcessingScope,
+		&log.Status,
+		&log.ActivitiesFound,
+		&log.ActivitiesProcessed,
+		&log.TotalDistanceMeters,
+		&log.TotalDurationSeconds,
+		&log.SpreadsheetRow,
+		&log.SpreadsheetUpdated,
+		&log.DescriptionGenerated,
+		&log.ErrorMessage,
+		&warningMessages,
+		&log.ProcessingStartedAt,
+		&log.ProcessingCompletedAt,
+		&log.ProcessingDurationMs,
+		&metadataJSON,
+		&log.CreatedAt,
+	)
+
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		r.logger.Error("Failed to get successful log for date", 
+			"error", err, 
+			"user_id", userID,
+			"processing_date", processingDate,
+			"processing_type", processingType)
+		return nil, fmt.Errorf("failed to get successful log for date: %w", err)
+	}
+
+	// Convert warning messages
+	log.WarningMessages = []string(warningMessages)
+
+	// Unmarshal metadata if present
+	if metadataJSON.Valid && len(metadataJSON.String) > 0 {
+		var metadata map[string]interface{}
+		if err := json.Unmarshal([]byte(metadataJSON.String), &metadata); err != nil {
+			r.logger.Warn("Failed to unmarshal metadata", "error", err, "log_id", log.ID)
+		} else {
+			log.Metadata = metadata
+		}
+	}
+
+	r.logger.Debug("Found existing successful log for date",
+		"user_id", userID,
+		"processing_date", processingDate,
+		"processing_type", processingType,
+		"log_id", log.ID)
+
+	return &log, nil
+}


### PR DESCRIPTION
## Summary

This PR prevents the creation of duplicate activity logs when automation runs multiple times on the same day and finds no new activities.

## Problem

Currently, when automation runs and finds no new activities, it creates a new activity log entry every time, even if there's already a successful log for that calendar day showing 0 activities found. This creates unnecessary duplicate entries in the database.

## Solution

- Added `GetSuccessfulLogForDate` method to check for existing successful logs with zero activities
- Modified `persistProcessingResult` to skip creating duplicate logs when:
  - Processing was successful
  - Zero activities were found  
  - An existing successful log with zero activities exists for the same day and processing type
- Maintains separation between manual and scheduled sync logs

## Benefits

- Reduces database clutter
- Makes activity logs more meaningful (each entry represents a unique event)
- Improves performance by reducing unnecessary database writes
- Better user experience when viewing activity history

## Testing

- All existing tests pass
- Updated mock implementation to support the new interface method
- The feature gracefully handles errors by logging warnings and proceeding with log creation

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved activity log management to prevent duplicate log entries for successful processing runs with no activities found on the same day and processing type.

* **Bug Fixes**
  * Enhanced reliability in logging by ensuring only one successful log entry is created under specific conditions.

* **Tests**
  * Updated test coverage to validate the new activity log handling logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->