### PR TITLE
Fix: Prevent duplicate logs and fix time format in Google Sheets

### DIFF
--- a/DEPLOY_SCHEDULER_STAGING.md
+++ b/DEPLOY_SCHEDULER_STAGING.md
@@ -224,7 +224,7 @@ If issues arise:
 ## Notes
 
 - The scheduler runs every hour at the top of the hour (UTC)
-- It will only process users who are in their 3-5 AM local time window
+- It will only process users who are in their 3:00-3:59 AM local time window
 - The placeholder auth middleware will accept the OIDC token from Cloud Scheduler
 - Monitor the first few runs closely to ensure proper operation
 - Consider setting up alerts for scheduler failures in production

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The Academy Sync eliminates the tedious, error-prone, and time-consuming task of
 - **Automated Data Transfer**: Fetches run data from Strava and logs it to Google Sheets according to coach-prescribed formatting rules
 - **Intelligent Processing**: Handles complex workout descriptions, RPE calculations, and data aggregation
 - **7-Day Lookback**: Automatically processes missed entries from the past week
-- **Smart Scheduling**: Processes data based on user's local timezone (3-5 AM window)
+- **Smart Scheduling**: Processes data based on user's local timezone (3:00-3:59 AM window)
 - **Manual Sync**: On-demand processing via web interface
 - **Email Notifications**: Daily summary emails with processing results
 - **Multi-User Ready**: Architected to support multiple users with isolated processing

--- a/cmd/automation-engine/internal/processing/worker.go
+++ b/cmd/automation-engine/internal/processing/worker.go
@@ -924,29 +924,14 @@ func (w *Worker) persistProcessingResult(ctx context.Context, userID int, jobTyp
 	}
 
 	// Check if we should skip creating a log entry
-	// Skip if: successful processing with zero activities found and an existing log exists for today
-	if status == "success" && result.TotalActivitiesFound == 0 {
-		// Use a separate context for the database check
-		checkCtx, checkCancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer checkCancel()
-		
-		existingLog, err := w.activityLogRepo.GetSuccessfulLogForDate(checkCtx, userID, processingDateOnly, processingType)
-		if err != nil {
-			w.logger.Warn("Failed to check for existing activity log, will create new log",
-				"error", err,
-				"user_id", userID,
-				"processing_date", processingDateOnly,
-				"processing_type", processingType)
-		} else if existingLog != nil {
-			// Found existing successful log with zero activities for today, skip creating duplicate
-			w.logger.Debug("Skipping activity log creation - already have successful zero-activity log for today",
-				"user_id", userID,
-				"processing_date", processingDateOnly,
-				"processing_type", processingType,
-				"existing_log_id", existingLog.ID,
-				"existing_log_created_at", existingLog.CreatedAt)
-			return
-		}
+	// Skip if: successful processing with zero activities found and no spreadsheet updates
+	if status == "success" && result.TotalActivitiesFound == 0 && rowsUpdated == 0 {
+		w.logger.Debug("Skipping activity log creation - no activities found and no spreadsheet updates",
+			"user_id", userID,
+			"processing_date", processingDateOnly,
+			"processing_type", processingType,
+			"job_type", jobType)
+		return
 	}
 
 	// Create activity log entry with full schema

--- a/docs/BRD.md
+++ b/docs/BRD.md
@@ -55,7 +55,7 @@ To address these challenges, an automated software system (MVP) is proposed. Thi
 
 The system will execute operational logic orchestrated by the Backend System after initial configuration via the Web UI. The process can be initiated in two ways:
 
-1. **Automated Scheduled Run:** A scheduler runs periodically (e.g., hourly). For every active user, it checks if the current time falls within their configured local processing window (e.g., 3-5 AM). If so, it dispatches an independent processing job for that user. This allows for parallel processing of many users.
+1. **Automated Scheduled Run:** A scheduler runs periodically (e.g., hourly). For every active user, it checks if the current time falls within their configured local processing window (3:00-3:59 AM). If so, it dispatches an independent processing job for that user. This allows for parallel processing of many users.
 2. **On-Demand Manual Run:** A user can trigger an immediate processing job for their account via the Web UI.
 
 Once a processing job for a user is initiated, it is decoupled from the notification system. The job retrieves the user's configuration and tokens, ensures API access, processes data for the relevant days (current, previous, and lookback), updates the Google Sheet, and records the outcomes. Upon completion, it dispatches a "send notification" job, which then generates and sends the summary email.
@@ -177,7 +177,7 @@ graph TD
 
 ### 3.2.3. Core Automation Logic
 
-- **FR-BE-CORE-001 (Scheduling)**: The Backend System MUST automatically initiate processing jobs for all active, configured users based on a configured time window (e.g., 3-5 AM) relative to each user's individual stored timezone. The scheduler should run periodically (e.g., hourly) to check which users fall into their processing window.
+- **FR-BE-CORE-001 (Scheduling)**: The Backend System MUST automatically initiate processing jobs for all active, configured users based on a configured time window (3:00-3:59 AM) relative to each user's individual stored timezone. The scheduler should run periodically (e.g., hourly) to check which users fall into their processing window.
 - **FR-BE-CORE-002 (Token Management)**: The engine MUST manage the lifecycle of short-lived API access tokens by using the long-lived refresh tokens to obtain new ones when needed. It must handle errors during this process, including flagging a user's connection for re-authorization if a refresh token is invalid.
 - **FR-BE-CORE-003 (Processing Scope)**: The engine must support distinct processing scopes: a scheduled run (previous day + 7-day lookback) and a manual run (current day so far + previous day + 7-day lookback).
 - **FR-BE-CORE-004 (Lookback Logic)**: The lookback process MUST check each of the 7 prior days and only process a day if a schedule entry exists and the day is not considered "processed." A day is considered "processed" if either the text in "Описание на тренировката" is bold OR the "Разстояние" column contains '0'.

--- a/internal/pkg/database/user_repository.go
+++ b/internal/pkg/database/user_repository.go
@@ -621,12 +621,12 @@ func (r *UserRepository) UpdateTimezone(ctx context.Context, userID int, timezon
 }
 
 // GetUsersInProcessingWindow retrieves all users who have automation enabled and whose
-// local time is within the processing window (3:00 AM - 5:00 AM).
+// local time is within the processing window (3:00 AM - 3:59 AM).
 // This method performs timezone calculations in the database to find users
 // whose current local time falls within their configured processing window.
 func (r *UserRepository) GetUsersInProcessingWindow(ctx context.Context) ([]int, error) {
 	// SQL query that calculates local time for each user based on their timezone
-	// and checks if it falls within the 3:00-5:00 AM window
+	// and checks if it falls within the 3:00-3:59 AM window
 	query := `
 		SELECT id 
 		FROM users 
@@ -636,7 +636,7 @@ func (r *UserRepository) GetUsersInProcessingWindow(ctx context.Context) ([]int,
 		  AND spreadsheet_id IS NOT NULL
 		  AND spreadsheet_id != ''
 		  AND EXTRACT(HOUR FROM (NOW() AT TIME ZONE timezone)) >= 3
-		  AND EXTRACT(HOUR FROM (NOW() AT TIME ZONE timezone)) < 5
+		  AND EXTRACT(HOUR FROM (NOW() AT TIME ZONE timezone)) < 4
 		ORDER BY id
 	`
 

--- a/internal/pkg/database/user_repository_test.go
+++ b/internal/pkg/database/user_repository_test.go
@@ -24,7 +24,7 @@ func TestGetUsersInProcessingWindow(t *testing.T) {
 	repo := NewUserRepository(db, encryptor)
 
 	// Define the expected query pattern that matches the actual implementation
-	expectedQuery := `SELECT id\s+FROM users\s+WHERE automation_enabled = true\s+AND strava_refresh_token IS NOT NULL\s+AND LENGTH\(strava_refresh_token\) > 0\s+AND spreadsheet_id IS NOT NULL\s+AND spreadsheet_id != ''\s+AND EXTRACT\(HOUR FROM \(NOW\(\) AT TIME ZONE timezone\)\) >= 3\s+AND EXTRACT\(HOUR FROM \(NOW\(\) AT TIME ZONE timezone\)\) < 5\s+ORDER BY id`
+	expectedQuery := `SELECT id\s+FROM users\s+WHERE automation_enabled = true\s+AND strava_refresh_token IS NOT NULL\s+AND LENGTH\(strava_refresh_token\) > 0\s+AND spreadsheet_id IS NOT NULL\s+AND spreadsheet_id != ''\s+AND EXTRACT\(HOUR FROM \(NOW\(\) AT TIME ZONE timezone\)\) >= 3\s+AND EXTRACT\(HOUR FROM \(NOW\(\) AT TIME ZONE timezone\)\) < 4\s+ORDER BY id`
 
 	tests := []struct {
 		name          string
@@ -116,7 +116,7 @@ func TestGetUsersInProcessingWindow(t *testing.T) {
 
 func TestGetUsersInProcessingWindow_Integration(t *testing.T) {
 	// Define the expected query pattern that matches the actual implementation
-	expectedQuery := `SELECT id\s+FROM users\s+WHERE automation_enabled = true\s+AND strava_refresh_token IS NOT NULL\s+AND LENGTH\(strava_refresh_token\) > 0\s+AND spreadsheet_id IS NOT NULL\s+AND spreadsheet_id != ''\s+AND EXTRACT\(HOUR FROM \(NOW\(\) AT TIME ZONE timezone\)\) >= 3\s+AND EXTRACT\(HOUR FROM \(NOW\(\) AT TIME ZONE timezone\)\) < 5\s+ORDER BY id`
+	expectedQuery := `SELECT id\s+FROM users\s+WHERE automation_enabled = true\s+AND strava_refresh_token IS NOT NULL\s+AND LENGTH\(strava_refresh_token\) > 0\s+AND spreadsheet_id IS NOT NULL\s+AND spreadsheet_id != ''\s+AND EXTRACT\(HOUR FROM \(NOW\(\) AT TIME ZONE timezone\)\) >= 3\s+AND EXTRACT\(HOUR FROM \(NOW\(\) AT TIME ZONE timezone\)\) < 4\s+ORDER BY id`
 
 	// This test demonstrates the timezone calculation logic
 	// It would require a real database connection to test properly
@@ -132,8 +132,8 @@ func TestGetUsersInProcessingWindow_Integration(t *testing.T) {
 		// Test that the query correctly filters by timezone
 		// Add test users with different timezones and verify filtering
 		rows := sqlmock.NewRows([]string{"id"}).
-			AddRow(1). // UTC user (4 AM - in window)
-			AddRow(3)  // Europe/London user (4-5 AM - in window)
+			AddRow(1). // UTC user (3 AM - in window)
+			AddRow(3)  // Europe/London user (3 AM - in window)
 
 		mock.ExpectQuery(expectedQuery).
 			WillReturnRows(rows)
@@ -150,7 +150,7 @@ func TestGetUsersInProcessingWindow_Integration(t *testing.T) {
 
 func TestGetUsersInProcessingWindow_RowScanError(t *testing.T) {
 	// Define the expected query pattern that matches the actual implementation
-	expectedQuery := `SELECT id\s+FROM users\s+WHERE automation_enabled = true\s+AND strava_refresh_token IS NOT NULL\s+AND LENGTH\(strava_refresh_token\) > 0\s+AND spreadsheet_id IS NOT NULL\s+AND spreadsheet_id != ''\s+AND EXTRACT\(HOUR FROM \(NOW\(\) AT TIME ZONE timezone\)\) >= 3\s+AND EXTRACT\(HOUR FROM \(NOW\(\) AT TIME ZONE timezone\)\) < 5\s+ORDER BY id`
+	expectedQuery := `SELECT id\s+FROM users\s+WHERE automation_enabled = true\s+AND strava_refresh_token IS NOT NULL\s+AND LENGTH\(strava_refresh_token\) > 0\s+AND spreadsheet_id IS NOT NULL\s+AND spreadsheet_id != ''\s+AND EXTRACT\(HOUR FROM \(NOW\(\) AT TIME ZONE timezone\)\) >= 3\s+AND EXTRACT\(HOUR FROM \(NOW\(\) AT TIME ZONE timezone\)\) < 4\s+ORDER BY id`
 
 	// Test handling of row scan errors
 	db, mock, err := sqlmock.New()

--- a/internal/pkg/google/sheets_client.go
+++ b/internal/pkg/google/sheets_client.go
@@ -794,27 +794,58 @@ func (c *SheetsClient) BatchUpdateTrainingPlan(ctx context.Context, spreadsheetI
 		})
 
 		// Column F (index 5): Time
-		requests = append(requests, &sheets.Request{
-			UpdateCells: &sheets.UpdateCellsRequest{
-				Start: &sheets.GridCoordinate{
-					SheetId:     sheetID,
-					RowIndex:    int64(update.Row - 1),
-					ColumnIndex: 5, // Column F
-				},
-				Rows: []*sheets.RowData{
-					{
-						Values: []*sheets.CellData{
-							{
-								UserEnteredValue: &sheets.ExtendedValue{
-									StringValue: &update.TimeValue,
+		// Convert time string to fractional day for proper Google Sheets time format
+		timeFraction, err := convertTimeToFractionalDay(update.TimeValue)
+		if err != nil {
+			c.logger.Warn("Failed to convert time to fractional day, using string format",
+				"time", update.TimeValue,
+				"error", err)
+			// Fallback to string value
+			requests = append(requests, &sheets.Request{
+				UpdateCells: &sheets.UpdateCellsRequest{
+					Start: &sheets.GridCoordinate{
+						SheetId:     sheetID,
+						RowIndex:    int64(update.Row - 1),
+						ColumnIndex: 5, // Column F
+					},
+					Rows: []*sheets.RowData{
+						{
+							Values: []*sheets.CellData{
+								{
+									UserEnteredValue: &sheets.ExtendedValue{
+										StringValue: &update.TimeValue,
+									},
 								},
 							},
 						},
 					},
+					Fields: "userEnteredValue",
 				},
-				Fields: "userEnteredValue",
-			},
-		})
+			})
+		} else {
+			// Use numeric value for proper time formatting
+			requests = append(requests, &sheets.Request{
+				UpdateCells: &sheets.UpdateCellsRequest{
+					Start: &sheets.GridCoordinate{
+						SheetId:     sheetID,
+						RowIndex:    int64(update.Row - 1),
+						ColumnIndex: 5, // Column F
+					},
+					Rows: []*sheets.RowData{
+						{
+							Values: []*sheets.CellData{
+								{
+									UserEnteredValue: &sheets.ExtendedValue{
+										NumberValue: &timeFraction,
+									},
+								},
+							},
+						},
+					},
+					Fields: "userEnteredValue",
+				},
+			})
+		}
 
 		// Column I (index 8): RPE
 		// Note: Google Sheets API accepts numeric values and will format them
@@ -922,4 +953,32 @@ func (c *SheetsClient) BatchUpdateTrainingPlan(ctx context.Context, spreadsheetI
 	}
 
 	return nil
+}
+
+// convertTimeToFractionalDay converts a time string in HH:MM:SS format to a fractional day value.
+// In Google Sheets, time is represented as a fraction of a day:
+// - 1.0 = 24 hours
+// - 0.5 = 12 hours
+// - 0.25 = 6 hours
+// For example, "01:30:00" (1 hour 30 minutes) = 0.0625 (1.5/24)
+func convertTimeToFractionalDay(timeStr string) (float64, error) {
+	// Handle zero time case
+	if timeStr == "00:00:00" || timeStr == "" {
+		return 0.0, nil
+	}
+
+	// Parse HH:MM:SS format
+	var hours, minutes, seconds int
+	_, err := fmt.Sscanf(timeStr, "%d:%d:%d", &hours, &minutes, &seconds)
+	if err != nil {
+		return 0.0, fmt.Errorf("invalid time format: %s", timeStr)
+	}
+
+	// Convert to total seconds
+	totalSeconds := float64(hours*3600 + minutes*60 + seconds)
+
+	// Convert to fraction of day (86400 seconds in a day)
+	fractionalDay := totalSeconds / 86400.0
+
+	return fractionalDay, nil
 }

--- a/internal/pkg/google/sheets_client_test.go
+++ b/internal/pkg/google/sheets_client_test.go
@@ -1,0 +1,124 @@
+package google
+
+import (
+	"testing"
+)
+
+func TestConvertTimeToFractionalDay(t *testing.T) {
+	tests := []struct {
+		name      string
+		timeStr   string
+		expected  float64
+		expectErr bool
+	}{
+		{
+			name:      "zero time",
+			timeStr:   "00:00:00",
+			expected:  0.0,
+			expectErr: false,
+		},
+		{
+			name:      "empty string",
+			timeStr:   "",
+			expected:  0.0,
+			expectErr: false,
+		},
+		{
+			name:      "one hour",
+			timeStr:   "01:00:00",
+			expected:  1.0 / 24.0, // 0.041666...
+			expectErr: false,
+		},
+		{
+			name:      "noon (12 hours)",
+			timeStr:   "12:00:00",
+			expected:  0.5,
+			expectErr: false,
+		},
+		{
+			name:      "1 hour 30 minutes",
+			timeStr:   "01:30:00",
+			expected:  1.5 / 24.0, // 0.0625
+			expectErr: false,
+		},
+		{
+			name:      "1 hour 10 minutes 10 seconds",
+			timeStr:   "01:10:10",
+			expected:  4210.0 / 86400.0, // ~0.04873
+			expectErr: false,
+		},
+		{
+			name:      "23:59:59",
+			timeStr:   "23:59:59",
+			expected:  86399.0 / 86400.0, // ~0.999988
+			expectErr: false,
+		},
+		{
+			name:      "invalid format",
+			timeStr:   "invalid",
+			expected:  0.0,
+			expectErr: true,
+		},
+		{
+			name:      "missing seconds",
+			timeStr:   "01:30",
+			expected:  0.0,
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := convertTimeToFractionalDay(tt.timeStr)
+			
+			if tt.expectErr {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+				}
+				return
+			}
+			
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+			
+			// Allow small floating point differences
+			const epsilon = 0.000001
+			if diff := result - tt.expected; diff < -epsilon || diff > epsilon {
+				t.Errorf("Expected %f, got %f (difference: %f)", tt.expected, result, diff)
+			}
+		})
+	}
+}
+
+// Test that common time values convert correctly
+func TestConvertTimeToFractionalDay_CommonValues(t *testing.T) {
+	testCases := []struct {
+		description string
+		time        string
+		hours       float64
+	}{
+		{"6 hours", "06:00:00", 6.0},
+		{"30 minutes", "00:30:00", 0.5},
+		{"1 hour 15 minutes", "01:15:00", 1.25},
+		{"2 hours 30 minutes 30 seconds", "02:30:30", 2.5083333},
+	}
+	
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			expected := tc.hours / 24.0
+			result, err := convertTimeToFractionalDay(tc.time)
+			
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			
+			// Verify the conversion is correct
+			const epsilon = 0.000001
+			if diff := result - expected; diff < -epsilon || diff > epsilon {
+				t.Errorf("For %s (%s): expected %f, got %f", tc.description, tc.time, expected, result)
+			}
+		})
+	}
+}

--- a/internal/pkg/services/scheduling_service.go
+++ b/internal/pkg/services/scheduling_service.go
@@ -33,7 +33,7 @@ func (s *SchedulingService) ProcessScheduledRun(ctx context.Context) (int, error
 	currentTime := time.Now().UTC()
 	s.logger.Info("Current UTC time", "time", currentTime.Format("2006-01-02 15:04:05 MST"))
 
-	// Get users whose local time is in the processing window (3:00-5:00 AM)
+	// Get users whose local time is in the processing window (3:00-3:59 AM)
 	userIDs, err := s.userRepo.GetUsersInProcessingWindow(ctx)
 	if err != nil {
 		s.logger.Error("Failed to get users in processing window", "error", err)

--- a/terraform/scheduler.tf
+++ b/terraform/scheduler.tf
@@ -20,7 +20,7 @@ resource "google_cloud_run_service_iam_member" "scheduler_invoker" {
 # Cloud Scheduler job for hourly automation processing
 resource "google_cloud_scheduler_job" "automation_scheduler" {
   name        = "${var.environment}-automation-scheduler"
-  description = "Hourly job to trigger automated processing for users in their 3-5 AM window"
+  description = "Hourly job to trigger automated processing for users in their 3-4 AM window"
   project     = var.project_id
   region      = var.region
 


### PR DESCRIPTION
## Summary
- Prevent duplicate activity logs when automation runs find no new workouts to process
- Fix time values being written as strings (with leading apostrophe) in Google Sheets
- Update automation time window to only run between 3:00-3:59 AM (excluding 4:00 AM)
- Update all documentation references to reflect the new time window

## Changes Made

### 1. Activity Log Behavior
Modified `persistProcessingResult` in `/cmd/automation-engine/internal/processing/worker.go` to skip creating activity logs when:
- Processing status is "success"
- No activities were found (`TotalActivitiesFound == 0`)
- No spreadsheet updates were made (`rowsUpdated == 0`)

This prevents duplicate logs in the activity history when automation runs but finds nothing to process.

### 2. Time Format Fix in Google Sheets
Fixed the issue where time values appeared with a leading apostrophe (e.g., '01:10:10) and couldn't be used in calculations:
- Added `convertTimeToFractionalDay` function to convert HH:MM:SS format to fractional day numbers
- Updated sheets client to use `NumberValue` instead of `StringValue` for time column
- Google Sheets expects time as fractions of a day (e.g., 0.5 = 12 hours, 0.25 = 6 hours)
- Added comprehensive tests for the conversion function

### 3. Time Window Update
Updated the automation eligibility window from 3:00-5:00 AM to 3:00-3:59 AM:
- Modified SQL query in `GetUsersInProcessingWindow` to use `< 4` instead of `< 5`
- Updated test expectations in `user_repository_test.go`
- Updated Terraform scheduler description
- Updated all documentation references

### 4. Documentation Updates
- `README.md`: Updated feature description
- `docs/BRD.md`: Updated business requirements
- `DEPLOY_SCHEDULER_STAGING.md`: Updated deployment notes

## Test Results
All tests pass after the changes.

## Why These Changes?
1. **Activity Logs**: Users were seeing duplicate log entries when automation ran but found no new workouts. This cluttered the activity history unnecessarily.
2. **Time Format**: Time values with leading apostrophes broke spreadsheet calculations and aggregations.
3. **Time Window**: Restricting to 3:00-3:59 AM ensures only one automation run per night, preventing potential duplicate processing.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Google Sheets integration: Time values in the training plan are now written as numeric fractional days, enabling proper time formatting in Google Sheets.

* **Bug Fixes**
  * Scheduling and user processing now consistently use a precise 3:00–3:59 AM local time window instead of a broader range.

* **Documentation**
  * Updated all relevant documentation and descriptions to reflect the new 3:00–3:59 AM processing window.

* **Tests**
  * Added and updated tests for time conversion logic and the new processing window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->