### PR TITLE
Fix: Prevent manual sync from processing current day without activities

### DIFF
--- a/cmd/automation-engine/internal/processing/processing_service.go
+++ b/cmd/automation-engine/internal/processing/processing_service.go
@@ -161,7 +161,7 @@ func (s *ProcessingService) ProcessPreviousDay(ctx context.Context, config *auto
 		"date", yesterdayStart.Format("2006-01-02"),
 		"timezone", config.Timezone)
 
-	return s.processSingleDay(ctx, config, yesterdayStart, trainingCache, activitiesCache)
+	return s.processSingleDay(ctx, config, yesterdayStart, trainingCache, activitiesCache, false)
 }
 
 // ProcessTodaySoFar processes the current calendar day up to the present moment (US028)
@@ -190,7 +190,7 @@ func (s *ProcessingService) ProcessTodaySoFar(ctx context.Context, config *autom
 		"current_time", now.Format("15:04:05"),
 		"timezone", config.Timezone)
 
-	return s.processSingleDay(ctx, config, todayStart, trainingCache, activitiesCache)
+	return s.processSingleDay(ctx, config, todayStart, trainingCache, activitiesCache, true)
 }
 
 // ProcessLookbackPeriod processes the 7-day lookback window (US026 & US027)
@@ -222,7 +222,7 @@ func (s *ProcessingService) ProcessLookbackPeriod(ctx context.Context, config *a
 			"date", dayStart.Format("2006-01-02"),
 			"days_ago", daysAgo)
 
-		result, err := s.processSingleDay(ctx, config, dayStart, trainingCache, activitiesCache)
+		result, err := s.processSingleDay(ctx, config, dayStart, trainingCache, activitiesCache, false)
 		if err != nil {
 			s.logger.Error("Failed to process lookback day",
 				"user_id", config.UserID,
@@ -500,7 +500,7 @@ func (s *ProcessingService) RunScheduledCycle(ctx context.Context, config *autom
 
 // processSingleDay contains the core logic for processing one calendar day
 // This is the heart of the automation engine that implements the BRD flowchart logic
-func (s *ProcessingService) processSingleDay(ctx context.Context, config *automation.ProcessingConfig, dayStart time.Time, trainingCache TrainingPlanCache, activitiesCache StravaActivitiesCache) (*DayProcessingResult, error) {
+func (s *ProcessingService) processSingleDay(ctx context.Context, config *automation.ProcessingConfig, dayStart time.Time, trainingCache TrainingPlanCache, activitiesCache StravaActivitiesCache, isManualSync bool) (*DayProcessingResult, error) {
 	result := &DayProcessingResult{
 		Date: dayStart,
 	}
@@ -587,14 +587,36 @@ func (s *ProcessingService) processSingleDay(ctx context.Context, config *automa
 	// Process if either:
 	// - There are activities to record
 	// - There's a scheduled run (even with no activities, we need to mark it as '0')
-	shouldProcess := result.ActivitiesFound > 0 || hasScheduledRun
+	// Special case: For manual sync on current day, only process if activities found
+	var shouldProcess bool
+	
+	// Check if this is a manual sync for the current day
+	location, _ := time.LoadLocation(config.Timezone)
+	currentDayStart := time.Now().In(location)
+	currentDayStart = time.Date(currentDayStart.Year(), currentDayStart.Month(), currentDayStart.Day(), 0, 0, 0, 0, location)
+	isCurrentDay := dayStart.Equal(currentDayStart)
+	
+	if isManualSync && isCurrentDay && result.ActivitiesFound == 0 {
+		// Manual sync on current day with no activities - skip to avoid marking as processed
+		shouldProcess = false
+		s.logger.Info("Manual sync on current day with no activities, skipping to keep unprocessed",
+			"user_id", config.UserID,
+			"date", dayStart.Format("2006-01-02"),
+			"has_scheduled_run", hasScheduledRun)
+	} else {
+		// Standard logic: process if activities found OR scheduled run exists
+		shouldProcess = result.ActivitiesFound > 0 || hasScheduledRun
+	}
 
 	if !shouldProcess {
 		result.Processed = false
 		result.SkippedReason = SkipReasonNoActivities
-		s.logger.Debug("No activities found and no scheduled run, skipping",
+		s.logger.Debug("Skipping day processing",
 			"user_id", config.UserID,
-			"date", dayStart.Format("2006-01-02"))
+			"date", dayStart.Format("2006-01-02"),
+			"reason", "no_activities_or_scheduled_run",
+			"is_manual_sync", isManualSync,
+			"is_current_day", isCurrentDay)
 		return result, nil
 	}
 

--- a/cmd/automation-engine/internal/processing/processing_service_test.go
+++ b/cmd/automation-engine/internal/processing/processing_service_test.go
@@ -232,7 +232,7 @@ func TestProcessSingleDay_NoTrainingPlan(t *testing.T) {
 	cache := make(TrainingPlanCache) // Empty cache
 
 	activitiesCache := make(StravaActivitiesCache)
-	result, err := service.processSingleDay(context.Background(), config, date, cache, activitiesCache)
+	result, err := service.processSingleDay(context.Background(), config, date, cache, activitiesCache, false)
 
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
@@ -266,7 +266,7 @@ func TestProcessSingleDay_AlreadyProcessed(t *testing.T) {
 	}
 
 	activitiesCache := make(StravaActivitiesCache)
-	result, err := service.processSingleDay(context.Background(), config, date, cache, activitiesCache)
+	result, err := service.processSingleDay(context.Background(), config, date, cache, activitiesCache, false)
 
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
@@ -317,7 +317,7 @@ func TestProcessSingleDay_RestDayWithActivity(t *testing.T) {
 		dateKey: mockStrava.activities,
 	}
 
-	result, err := service.processSingleDay(context.Background(), config, date, cache, activitiesCache)
+	result, err := service.processSingleDay(context.Background(), config, date, cache, activitiesCache, false)
 
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
@@ -359,7 +359,7 @@ func TestProcessSingleDay_ScheduledRunNoActivity(t *testing.T) {
 		dateKey: []strava.Activity{},
 	}
 
-	result, err := service.processSingleDay(context.Background(), config, date, cache, activitiesCache)
+	result, err := service.processSingleDay(context.Background(), config, date, cache, activitiesCache, false)
 
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
@@ -414,7 +414,7 @@ func TestProcessing_SingleAPICall(t *testing.T) {
 	// Process multiple days using the cache
 	for i := 0; i < 3; i++ {
 		date := startDate.AddDate(0, 0, i)
-		_, _ = service.processSingleDay(context.Background(), config, date, cache, activitiesCache)
+		_, _ = service.processSingleDay(context.Background(), config, date, cache, activitiesCache, false)
 	}
 
 	// Verify no additional API calls were made
@@ -710,7 +710,7 @@ func TestSpreadsheetUpdatePreparation(t *testing.T) {
 		dateKey: mockStrava.activities,
 	}
 
-	result, err := service.processSingleDay(context.Background(), config, date, cache, activitiesCache)
+	result, err := service.processSingleDay(context.Background(), config, date, cache, activitiesCache, false)
 
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
@@ -1304,5 +1304,176 @@ func TestRunScheduledCycle_MixedProcessedDays(t *testing.T) {
 	// Verify batch update was called if there were unprocessed days
 	if result.ProcessedDays > 0 && mockSheets.batchUpdateCalls == 0 {
 		t.Error("Expected batch update to be called for unprocessed days")
+	}
+}
+
+// Test manual sync on current day with no activities doesn't process
+func TestProcessSingleDay_ManualSyncCurrentDayNoActivities(t *testing.T) {
+	location, _ := time.LoadLocation("Europe/Sofia")
+	now := time.Now().In(location)
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, location)
+	
+	// No activities for today
+	mockStrava := &MockStravaClient{
+		activities: []strava.Activity{},
+	}
+	mockSheets := &MockSheetsClient{}
+	
+	service := NewProcessingService(mockStrava, mockSheets, nil, createTestLogger())
+	config := createTestConfig(1, "Europe/Sofia")
+	
+	// Create training plan cache with scheduled run for today
+	cache := TrainingPlanCache{
+		today.Format("2006-01-02"): &TrainingPlanEntry{
+			Date:         today,
+			ActivityType: "Бягане", // Scheduled run
+			Description:  "Easy run",
+			RPE:          5,
+			IsProcessed:  false,
+			Row:          2,
+		},
+	}
+	
+	// Create empty activities cache
+	activitiesCache := StravaActivitiesCache{
+		today.Format("2006-01-02"): []strava.Activity{},
+	}
+	
+	// Test manual sync (isManualSync = true)
+	result, err := service.processSingleDay(context.Background(), config, today, cache, activitiesCache, true)
+	
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	
+	// Verify the day was NOT processed
+	if result.Processed {
+		t.Error("Expected day not to be processed for manual sync with no activities")
+	}
+	
+	if result.SkippedReason != SkipReasonNoActivities {
+		t.Errorf("Expected skip reason to be NoActivities, got: %s", result.SkippedReason.String())
+	}
+	
+	// Verify no spreadsheet update
+	if result.SpreadsheetUpdate != nil {
+		t.Error("Expected no spreadsheet update for skipped day")
+	}
+}
+
+// Test manual sync on current day with activities does process
+func TestProcessSingleDay_ManualSyncCurrentDayWithActivities(t *testing.T) {
+	location, _ := time.LoadLocation("Europe/Sofia")
+	now := time.Now().In(location)
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, location)
+	
+	// Add activity for today
+	mockStrava := &MockStravaClient{
+		activities: []strava.Activity{
+			{
+				ID:         123,
+				Name:       "Morning Run",
+				Type:       "Run",
+				Distance:   5000,
+				MovingTime: 1800,
+				StartDate:  today.Add(8 * time.Hour),
+			},
+		},
+	}
+	mockSheets := &MockSheetsClient{}
+	
+	service := NewProcessingService(mockStrava, mockSheets, nil, createTestLogger())
+	config := createTestConfig(1, "Europe/Sofia")
+	
+	// Create training plan cache with scheduled run for today
+	cache := TrainingPlanCache{
+		today.Format("2006-01-02"): &TrainingPlanEntry{
+			Date:         today,
+			ActivityType: "Бягане",
+			Description:  "Easy run",
+			RPE:          5,
+			IsProcessed:  false,
+			Row:          2,
+		},
+	}
+	
+	// Create activities cache with the activity
+	activitiesCache := StravaActivitiesCache{
+		today.Format("2006-01-02"): mockStrava.activities,
+	}
+	
+	// Test manual sync (isManualSync = true)
+	result, err := service.processSingleDay(context.Background(), config, today, cache, activitiesCache, true)
+	
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	
+	// Verify the day WAS processed
+	if !result.Processed {
+		t.Error("Expected day to be processed for manual sync with activities")
+	}
+	
+	if result.ActivitiesFound != 1 {
+		t.Errorf("Expected 1 activity found, got %d", result.ActivitiesFound)
+	}
+	
+	// Verify spreadsheet update exists
+	if result.SpreadsheetUpdate == nil {
+		t.Error("Expected spreadsheet update for processed day")
+	}
+}
+
+// Test scheduled sync behavior remains unchanged (processes even with no activities)
+func TestProcessSingleDay_ScheduledSyncNoActivities(t *testing.T) {
+	date := parseTestDate("2025-05-01", "Europe/Sofia")
+	
+	// No activities
+	mockStrava := &MockStravaClient{
+		activities: []strava.Activity{},
+	}
+	mockSheets := &MockSheetsClient{}
+	
+	service := NewProcessingService(mockStrava, mockSheets, nil, createTestLogger())
+	config := createTestConfig(1, "Europe/Sofia")
+	
+	cache := TrainingPlanCache{
+		date.Format("2006-01-02"): &TrainingPlanEntry{
+			Date:         date,
+			ActivityType: "Бягане", // Scheduled run
+			Description:  "Easy run",
+			RPE:          5,
+			IsProcessed:  false,
+			Row:          2,
+		},
+	}
+	
+	activitiesCache := StravaActivitiesCache{
+		date.Format("2006-01-02"): []strava.Activity{},
+	}
+	
+	// Test scheduled sync (isManualSync = false)
+	result, err := service.processSingleDay(context.Background(), config, date, cache, activitiesCache, false)
+	
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	
+	// Verify the day WAS processed (scheduled run with no activities)
+	if !result.Processed {
+		t.Error("Expected day to be processed for scheduled run even with no activities")
+	}
+	
+	if result.SpreadsheetUpdate == nil {
+		t.Error("Expected spreadsheet update")
+	}
+	
+	// Verify zero values written
+	if result.SpreadsheetUpdate.DistanceValue != "0" {
+		t.Errorf("Expected distance '0', got %s", result.SpreadsheetUpdate.DistanceValue)
+	}
+	
+	if result.SpreadsheetUpdate.TimeValue != "00:00:00" {
+		t.Errorf("Expected time '00:00:00', got %s", result.SpreadsheetUpdate.TimeValue)
 	}
 }


### PR DESCRIPTION
## Summary
Prevents manual sync from marking the current day as processed when no activities are found, allowing users to run later in the day without issues.

## Problem
Users were clicking manual sync before their morning run, which would:
1. Find no activities for the current day
2. Mark the scheduled run as processed with "0" distance and "00:00:00" time
3. Prevent the actual run from being logged later

## Solution
Modified the processing logic to distinguish between manual and scheduled syncs:
- **Manual sync on current day**: Only processes if activities are found
- **Scheduled sync**: Maintains existing behavior (marks as "0" if no activities)
- **Previous days and lookback**: Unchanged for both sync types

## Implementation Details
1. Added `isManualSync bool` parameter to `processSingleDay` function
2. Added special logic: if manual sync + current day + no activities = skip processing
3. Updated all function calls to pass appropriate `isManualSync` value:
   - `ProcessTodaySoFar`: passes `true` (manual sync)
   - `ProcessPreviousDay`: passes `false` 
   - `ProcessLookbackPeriod`: passes `false`

## Tests Added
- `TestProcessSingleDay_ManualSyncCurrentDayNoActivities`: Verifies no processing occurs
- `TestProcessSingleDay_ManualSyncCurrentDayWithActivities`: Verifies processing with activities
- `TestProcessSingleDay_ScheduledSyncNoActivities`: Confirms scheduled behavior unchanged

All existing tests pass.

## Benefits
- Users can safely use manual sync anytime during the day
- Current day remains unprocessed until activities are recorded
- Scheduled runs still get marked as "0" if missed
- No changes to historical data processing

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of manual syncs for the current day, ensuring days without activities are not incorrectly marked as processed.
  * Enhanced debug logging to provide clearer reasons when processing is skipped.

* **Tests**
  * Added tests to verify correct processing behavior for manual and scheduled syncs, especially for the current day with or without activities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->